### PR TITLE
chore: travis to test on nodejs 8 instead of 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ notifications:
   email: false
 matrix:
   include:
+    - node_js: "8"
     - node_js: "6"
     - node_js: "4"
-    - node_js: "0.12"
 script:
   - npm test
 before_script:


### PR DESCRIPTION
Nodejs 0.12 is no longer supported, and starts to fail because our dependencies are not compatible.