### PR TITLE
chore: snyk policy update

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,53 +2,10 @@
 version: v1.7.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  'npm:ms:20170412':
-    - snyk > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.527Z'
-    - snyk > snyk-config > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.527Z'
-    - snyk > snyk-module > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.527Z'
-    - snyk > snyk-policy > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.527Z'
-    - snyk > snyk-resolve > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.584Z'
-    - snyk > snyk-resolve-deps > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.584Z'
-    - snyk > snyk-try-require > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.585Z'
-    - snyk > snyk-policy > snyk-module > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.585Z'
-    - snyk > snyk-policy > snyk-resolve > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.585Z'
-    - snyk > snyk-resolve-deps > snyk-resolve > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.585Z'
-    - snyk > snyk-policy > snyk-try-require > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.585Z'
-    - snyk > snyk-resolve-deps > snyk-try-require > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.585Z'
-    - snyk > snyk-resolve-deps > clite > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.586Z'
-    - snyk > snyk-resolve-deps > snyk-module > debug > ms:
-        reason: None given
-        expires: '2017-06-15T18:12:58.586Z'
   'npm:marked:20170907':
     - marked:
         reason: None given
-        expires: '2017-10-26T07:31:32.111Z'
+        expires: '2018-10-26T07:31:32.111Z'
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:marked:20170112':


### PR DESCRIPTION
Cleaning up the policy, extending `marked` vuln ignore duration