### PR TITLE
fix: crash on missing description

### DIFF
--- a/lib/snyk-to-html.js
+++ b/lib/snyk-to-html.js
@@ -9,14 +9,17 @@ var severityMap = {low: 0, medium: 1, high: 2};
 module.exports = {run: run };
 
 function metadataForVuln(vuln) {
+// Handling empty description and/or info cases - only description is causing the crash.
+  var description = vuln.description?vuln.description:"No description available.";
+  var info = vuln.description?vuln.description:"No information available.";
   return {
     id: vuln.id,
     title: vuln.title,
     name: vuln.name,
-    info: vuln.info,
+    info: info,
     severity: vuln.severity,
     severityValue: severityMap[vuln.severity],
-    description: vuln.description,
+    description: description,
   };
 }
 

--- a/lib/snyk-to-html.js
+++ b/lib/snyk-to-html.js
@@ -9,17 +9,14 @@ var severityMap = {low: 0, medium: 1, high: 2};
 module.exports = {run: run };
 
 function metadataForVuln(vuln) {
-// Handling empty description and/or info cases - only description is causing the crash.
-  var description = vuln.description?vuln.description:"No description available.";
-  var info = vuln.description?vuln.description:"No information available.";
   return {
     id: vuln.id,
     title: vuln.title,
     name: vuln.name,
-    info: info,
+    info: vuln.info || "No information available.",
     severity: vuln.severity,
     severityValue: severityMap[vuln.severity],
-    description: description,
+    description: vuln.description || 'No description available.',
   };
 }
 

--- a/lib/snyk-to-html.js
+++ b/lib/snyk-to-html.js
@@ -13,7 +13,7 @@ function metadataForVuln(vuln) {
     id: vuln.id,
     title: vuln.title,
     name: vuln.name,
-    info: vuln.info || "No information available.",
+    info: vuln.info || 'No information available.',
     severity: vuln.severity,
     severityValue: severityMap[vuln.severity],
     description: vuln.description || 'No description available.',

--- a/snyk-to-html.js
+++ b/snyk-to-html.js
@@ -24,6 +24,9 @@ var hbTemplate = Handlebars.compile(htmlTemplate);
 var severityMap = {low: 0, medium: 1, high: 2};
 
 function metadataForVuln(vuln) {
+  // Handling empty description cases
+  var description = vuln.description?vuln.description:"No description available.";
+
  return {
    id: vuln.id,
    title: vuln.title,
@@ -31,7 +34,7 @@ function metadataForVuln(vuln) {
    info: vuln.info,
    severity: vuln.severity,
    severityValue: severityMap[vuln.severity],
-   description: vuln.description,
+   description: description,
  };
 }
 

--- a/snyk-to-html.js
+++ b/snyk-to-html.js
@@ -23,19 +23,15 @@ var hbTemplate = Handlebars.compile(htmlTemplate);
 var severityMap = {low: 0, medium: 1, high: 2};
 
 function metadataForVuln(vuln) {
-  // Handling empty description and/or info cases - only description is causing the crash.
-  var description = vuln.description?vuln.description:"No description available.";
-  var info = vuln.description?vuln.description:"No information available.";
-
- return {
-   id: vuln.id,
-   title: vuln.title,
-   name: vuln.name,
-   info: vuln.info,
-   severity: vuln.severity,
-   severityValue: severityMap[vuln.severity],
-   description: description,
- };
+  return {
+    id: vuln.id,
+    title: vuln.title,
+    name: vuln.name,
+    info: vuln.info || "No information available.",
+    severity: vuln.severity,
+    severityValue: severityMap[vuln.severity],
+    description: vuln.description || 'No description available.',
+  };
 }
 
 function groupVulns(vulns) {

--- a/snyk-to-html.js
+++ b/snyk-to-html.js
@@ -18,14 +18,14 @@ if(argv['i']){ //input source
 if(argv['o']){ //output destination
   output = argv['o']; //grab the next item
 }
-
 var htmlTemplate = fs.readFileSync(template, 'utf8');
 var hbTemplate = Handlebars.compile(htmlTemplate);
 var severityMap = {low: 0, medium: 1, high: 2};
 
 function metadataForVuln(vuln) {
-  // Handling empty description cases
+  // Handling empty description and/or info cases - only description is causing the crash.
   var description = vuln.description?vuln.description:"No description available.";
+  var info = vuln.description?vuln.description:"No information available.";
 
  return {
    id: vuln.id,
@@ -95,6 +95,7 @@ function readInputFromStdin() {
 }
 
 function run() {
+
   if (source) {
     readInputFromFile(source, onDataCallback);
   } else {

--- a/snyk-to-html.js
+++ b/snyk-to-html.js
@@ -27,7 +27,7 @@ function metadataForVuln(vuln) {
     id: vuln.id,
     title: vuln.title,
     name: vuln.name,
-    info: vuln.info || "No information available.",
+    info: vuln.info || 'No information available.',
     severity: vuln.severity,
     severityValue: severityMap[vuln.severity],
     description: vuln.description || 'No description available.',

--- a/test/fixtures/expected-output-empty-description-case.html
+++ b/test/fixtures/expected-output-empty-description-case.html
@@ -1,0 +1,379 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="en-us">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Snyk test report</title>
+    <meta name="description" content="11 known vulnerabilities found in 1 vulnerable dependency paths.">
+    <link rel="icon" type="image/png" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.png" sizes="194x194">
+    <link rel="shortcut icon" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.ico">
+    <!--<link rel="stylesheet" href="https://static.snyk.io/prod/static-assets/style/build/initial.min.67beb0802da87abfd2bd1a320acac842.md5.css">-->
+  </head>
+  <body class="section-projects">
+
+<main class="layout-stacked">
+
+  <style type="text/css">
+
+  body {
+    -moz-font-feature-settings: "pnum";
+    -webkit-font-feature-settings: "pnum";
+    font-variant-numeric: proportional-nums;
+    display: flex;
+    flex-direction: column;
+    font-feature-settings: "pnum";
+    font-size: 100%;
+    line-height: 1.5;
+    min-height: 100vh;
+    -webkit-text-size-adjust: 100%;
+    margin: 0;
+    padding: 0;
+    background-color: #F5F5F5;
+    font-family: 'Arial', 'Helvetica', Calibri, sans-serif;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-weight: 500;
+  }
+
+  a,
+  a:link,
+  a:visited {
+    border-bottom: 1px solid #4b45a9;
+    text-decoration: none;
+    color: #4b45a9;
+  }
+
+  a:hover,
+  a:focus,
+  a:active {
+    border-bottom: 2px solid #4b45a9;
+  }
+
+  hr {
+    border: none;
+    margin: 1em 0;
+    border-top: 1px solid #c5c5c5;
+  }
+
+  ul {
+    padding: 0 1em;
+    margin: 1em 0;
+  }
+
+  code {
+    background-color: #EEE;
+    color: #333;
+    padding: 0.25em 0.5em;
+    border-radius: 0.25em;
+  }
+
+  pre {
+    background-color: #333;
+    font-family: monospace;
+    padding: 0.5em 1em 0.75em;
+    border-radius: 0.25em;
+    font-size: 14px;
+  }
+
+  pre code {
+    padding: 0;
+    background-color: transparent;
+    color: #fff;
+  }
+
+  a code {
+    border-radius: .125rem .125rem 0 0;
+    padding-bottom: 0;
+    color: #4b45a9;
+  }
+
+  a[href^="http://"]:after,
+  a[href^="https://"]:after {
+    background-image: linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20id%3D%22Page-1%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20id%3D%22link-external%22%3E%3Cg%20id%3D%22arrow%22%3E%3Cpath%20id%3D%22Line%22%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20id%3D%22Triangle%22%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20id%3D%22square%22%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+    background-repeat: no-repeat;
+    background-size: .75rem;
+    content: "";
+    display: inline-block;
+    height: .75rem;
+    margin-left: .25rem;
+    width: .75rem;
+  }
+
+
+/* Layout */
+
+  [class*=layout-container] {
+    margin: 0 auto;
+    max-width: 71.25em;
+    padding: 1.9em 1.3em;
+    position: relative;
+  }
+  .layout-container--short {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .layout-container--short:after {
+    display: block;
+    content: "";
+    clear: both;
+  }
+
+/* Header */
+
+  .header {
+    padding-bottom: 1px;
+  }
+
+  .project__header {
+    background-color: #4C4A73;
+    color: #fff;
+    margin-bottom: -1px;
+    padding-top: 1em;
+    padding-bottom: 0.25em;
+    border-bottom: 2px solid #BBB;
+  }
+
+  .project__header__title {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-all;
+    margin-bottom: .1em;
+    margin-top: 0;
+    float: left;
+  }
+
+  .timestamp {
+    float: right;
+    clear: none;
+    margin-bottom: 0;
+  }
+
+  .meta-counts {
+    clear: both;
+    display: block;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin: 0 0 1.5em;
+    color: #fff;
+    clear: both;
+    font-size: 1.1em;
+  }
+
+  .meta-count {
+    display: block;
+    flex-basis: 100%;
+    margin: 0 1em 1em 0;
+    float: left;
+    padding-right: 1em;
+    border-right: 2px solid #fff;
+  }
+
+  .meta-count:last-child {
+    border-right: 0;
+    padding-right: 0;
+    margin-right: 0;
+  }
+
+/* Card */
+
+  .card {
+    background-color: #fff;
+    border: 1px solid #c5c5c5;
+    border-radius: .25rem;
+    margin: 0 0 2em 0;
+    position: relative;
+    min-height: 40px;
+    padding: 1.5em;
+  }
+
+  .card .label {
+    background-color: #767676;
+    border: 2px solid #767676;
+    color: white;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    display: inline-block;
+    margin: 0;
+    border-radius: 0.25rem;
+  }
+
+  .card .label__text {
+    vertical-align: text-top;
+  }
+
+  .card .label--high {
+    background-color: #B51B72;
+    border-color: #B51B72;
+  }
+
+  .card .label--medium {
+    background-color: #E29022;
+    border-color: #E29022;
+  }
+
+  .card .label--low {
+    background-color: #222049;
+    border-color: #222049;
+  }
+
+  .card .card.severity--low {
+    border-color: #222049;
+  }
+
+  .card .card.severity--medium {
+    border-color: #E29022;
+  }
+
+  .card .card.severity--high {
+    border-color: #B51B72;
+  }
+
+  .card--vuln {
+    padding-top: 4em;
+    max-width: 48.75em;
+  }
+
+  .card--vuln .label {
+    left: 0;
+    position: absolute;
+    top: 1.1em;
+    padding-left: 1.9em;
+    padding-right: 1.9em;
+    border-radius: 0 0.25rem 0.25rem 0;
+  }
+
+  .card--vuln .card__section h2 {
+    font-size: 22px;
+    margin-bottom: 0.5em;
+  }
+
+  .card--vuln .card__section p {
+    margin: 0 0 0.5em 0;
+  }
+
+  .card--vuln .card__meta {
+    padding: 0 0 0 1em;
+    margin: 0;
+    font-size: 1.1em;
+  }
+
+  .card .card__meta__paths {
+    font-size: 0.9em;
+  }
+
+  .card--vuln .card__title {
+    font-size: 28px;
+    margin-top: 0;
+  }
+
+  .card--vuln .card__cta p {
+    margin: 0;
+    text-align: right;
+  }
+
+  </style>
+
+  <div class="layout-stacked__header header">
+
+    <header class="project__header">
+      <div class="layout-container--short">
+        <h1 class="project__header__title" style="margin-bottom: 0.5em;">
+          Snyk test report
+        </h1>
+        <p class="timestamp">November 8th 2017, 8:27:48 pm</p>
+        <div class="meta-counts">
+          <div class="meta-count">
+            <span>11</span> <span>known vulnerabilities</span>
+
+          </div>
+          <div class="meta-count"><span>1 vulnerable dependency paths</span></div>
+          <div class="meta-count"><span>140</span> <span>dependencies</span></div>
+        </div><!-- .meta-counts -->
+      </div><!-- .layout-container--short -->
+    </header><!-- .project__header -->
+
+  </div><!-- .layout-stacked__header -->
+
+  <div class="layout-stacked__content">
+
+    <div class="layout-container--short" style="padding-top: 35px;">
+
+      <div class="cards--vuln filter--patch filter--ignore">
+
+        <div class="card card--vuln  disclosure--not-new severity--medium" >
+
+          <h2 class="card__title">MPL-2.0 license</h2>
+
+          <div class="card__section">
+
+            <div class="label label--medium">
+              <span class="label__text">medium severity</span>
+            </div>
+
+            <hr/>
+
+            <ul class="card__meta">
+              <li class="card__meta__item">Module:
+                org.mozilla:rhino
+              </li>
+
+              <li class="card__meta__item">Introduced through:
+
+                  
+
+                  
+                  mytestmodule@0.0.0, com.github.fge:json-schema-validator@2.2.6 and others
+
+
+                </li>
+
+              </ul>
+
+            <hr/>
+
+            <h3 class="card__section__title">Detailed paths</h3>
+
+            <ul class="card__meta__paths">
+              <li>
+                <span class="list-paths__item__introduced"><em>Introduced through</em>: mytestmodule@0.0.0 <span class="list-paths__item__arrow">›</span> com.github.fge:json-schema-validator@2.2.6 <span class="list-paths__item__arrow">›</span> com.github.fge:json-schema-core@1.2.5 <span class="list-paths__item__arrow">›</span> org.mozilla:rhino@1.7R4</span>
+                </li>
+              </li>
+
+            </ul><!-- .list-paths -->
+
+          </div><!-- .card__section -->
+
+          <hr/>
+
+            <!-- Overview -->
+            <p>No description available.</p>
+
+
+          <hr/>
+
+          <div class="cta card__cta">
+            <p><a href="https://snyk.io/vuln/snyk:lic:maven:org.mozilla:rhino:MPL-2.0">More about this vulnerability</a></p>
+          </div>
+
+        </div><!-- .card -->
+
+      </div><!-- cards -->
+
+    </div>
+
+  </div><!-- .layout-container -->
+
+</main><!-- .layout-stacked__content -->
+
+</body>
+</html>

--- a/test/fixtures/test-report-empty-descr.json
+++ b/test/fixtures/test-report-empty-descr.json
@@ -1,0 +1,66 @@
+{
+  "ok": false,
+  "vulnerabilities": [
+    {
+      "license": "MPL-2.0",
+      "semver": {
+        "vulnerable": [
+          ">=1.7R4"
+        ]
+      },
+      "id": "snyk:lic:maven:org.mozilla:rhino:MPL-2.0",
+      "type": "license",
+      "packageManager": "maven",
+      "language": "java",
+      "packageName": "org.mozilla:rhino",
+      "title": "MPL-2.0 license",
+      "publicationTime": "2017-10-25T04:21:25.576Z",
+      "creationTime": "2017-10-25T04:21:25.576Z",
+      "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/MPL-2.0.txt",
+      "severity": "medium",
+      "from": [
+        "mytestmodule@0.0.0",
+        "com.github.fge:json-schema-validator@2.2.6",
+        "com.github.fge:json-schema-core@1.2.5",
+        "org.mozilla:rhino@1.7R4"
+      ],
+      "upgradePath": [],
+      "version": "1.7R4",
+      "name": "org.mozilla:rhino",
+      "isUpgradable": false,
+      "isPatchable": false
+    }
+  ],
+  "dependencyCount": 140,
+  "org": "snyk",
+  "licensesPolicy": {
+    "severities": {
+      "MS-RL": "medium",
+      "EPL-1.0": "medium",
+      "GPL-2.0": "high",
+      "GPL-3.0": "high",
+      "MPL-1.1": "medium",
+      "MPL-2.0": "medium",
+      "AGPL-1.0": "high",
+      "AGPL-3.0": "high",
+      "CDDL-1.0": "medium",
+      "LGPL-2.0": "medium",
+      "LGPL-2.1": "medium",
+      "LGPL-3.0": "medium",
+      "CPOL-1.02": "high",
+      "LGPL-2.1+": "medium",
+      "LGPL-3.0+": "medium",
+      "SimPL-2.0": "high",
+      "Artistic-1.0": "medium",
+      "Artistic-2.0": "medium"
+    }
+  },
+  "isPrivate": true,
+  "packageManager": "maven",
+  "summary": "1 vulnerable dependency paths",
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 11
+}

--- a/test/snyk-to-html.test.js
+++ b/test/snyk-to-html.test.js
@@ -12,3 +12,14 @@ test('all-around test', function (t) {
       t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>');
     });
 });
+
+
+test('empty values test (description and info)', function (t) {
+  t.plan(1);
+  snykToHtml.run(
+    __dirname + '/fixtures/test-report-empty-descr.json',
+    __dirname + '/../template/test-report.hbs',
+    function (report) {
+      t.contains(report, '<p>No description available.</p>');
+    });
+});


### PR DESCRIPTION
Reported issues with the report generation. Turns out issues reported without description are causing a marked crash "replace not working on undefined". Slight tweak to handle these cases.