### PR TITLE
chore: add pkg to semantic-release process

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,47 @@
+{
+  "prepare": [
+    "@semantic-release/npm",
+    {
+      "path": "@semantic-release/exec",
+      "cmd": "npm i -g pkg && pkg . && shasum -a 256 snyk-to-html-linux > snyk-to-html-linux.sha256 && shasum -a 256 snyk-to-html-macos > snyk-to-html-macos.sha256 && shasum -a 256 snyk-to-html-windows.exe > snyk-to-html-windows.exe.sha256"
+    }
+  ],
+  "publish": [
+    "@semantic-release/npm",
+    {
+      "path": "@semantic-release/github",
+      "assets": [
+        {
+          "path": "./snyk-to-html-linux",
+          "name": "snyk-to-html-linux",
+          "label": "snyk-to-html-linux"
+        },
+        {
+          "path": "./snyk-to-html-linux.sha256",
+          "name": "snyk-to-html-linux.sha256",
+          "label": "snyk-to-html-linux.sha256"
+        },
+        {
+          "path": "./snyk-to-html-macos",
+          "name": "snyk-to-html-macos",
+          "label": "snyk-to-html-macos"
+        },
+        {
+          "path": "./snyk-to-html-macos.sha256",
+          "name": "snyk-to-html-macos.sha256",
+          "label": "snyk-to-html-macos.sha256"
+        },
+        {
+          "path": "./snyk-to-html-windows.exe",
+          "name": "snyk-to-html-windows.exe",
+          "label": "snyk-to-html-windows.exe"
+        },
+        {
+          "path": "./snyk-to-html-windows.exe.sha256",
+          "name": "snyk-to-html-windows.exe.sha256",
+          "label": "snyk-to-html-windows.exe.sha256"
+        }
+      ]
+    }
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
       node_js: "8"
       script: skip
       after_success:
-        - npx semantic-release
+        - npm i -g semantic-release @semantic-release/exec && semantic-release
 branches:
   only:
     - master

--- a/package.json
+++ b/package.json
@@ -45,5 +45,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/snyk/snyk-to-html.git"
+  },
+  "pkg": {
+    "scripts": [
+      "dist/**/*.js"
+    ]
   }
 }


### PR DESCRIPTION
This PR fixes #26 and allow to package `snyk-to-html` into an executable.

P.S.: The code is shamelessly "stolen" from snyk CLI repository.