### PR TITLE
Fix: count vulns from data

### DIFF
--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -77,6 +77,7 @@ async function registerPeerPartial(templatePath: string, name: string): Promise<
 
 async function generateTemplate(data: any, template: string): Promise<string> {
   data.vulnerabilities = groupVulns(data.vulnerabilities);
+  data.uniqueCount = Object.keys(data.vulnerabilities).length;
 
   await registerPeerPartial(template, 'inline-css');
   await registerPeerPartial(template, 'vuln-card');
@@ -106,14 +107,7 @@ function mergeData(dataArray: any[]): any {
 }
 
 async function processData(data: any, template: string): Promise<string> {
-  let mergedData = {};
-  if (Array.isArray(data)) {
-    mergedData = mergeData(data);
-  } else {
-    data.uniqueCount = data.vulnerabilities.length;
-    mergedData = data;
-  }
-
+  const mergedData = Array.isArray(data) ? mergeData(data) : data;
   return generateTemplate(mergedData, template);
 }
 

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -108,7 +108,7 @@ function mergeData(dataArray: any[]): any {
 async function processData(data: any, template: string): Promise<string> {
   let mergedData = {};
   if (Array.isArray(data)) {
-    mergeData(data);
+    mergedData = mergeData(data);
   } else {
     data.uniqueCount = data.vulnerabilities.length;
     mergedData = data;

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -6,7 +6,7 @@ import marked = require('marked');
 import moment = require('moment');
 import path = require('path');
 
-const severityMap = {low: 0, medium: 1, high: 2};
+const severityMap = { low: 0, medium: 1, high: 2 };
 
 function readFile(filePath: string, encoding: string): Promise<string> {
   return new Promise<string>((resolve, reject) => {
@@ -54,9 +54,9 @@ function groupVulns(vulns) {
   if (!vulns || typeof vulns.length === 'undefined') {
     return result;
   }
-  vulns.map( vuln => {
+  vulns.map(vuln => {
     if (!result[vuln.id]) {
-      result[vuln.id] = {list: [vuln], metadata: metadataForVuln(vuln)};
+      result[vuln.id] = { list: [vuln], metadata: metadataForVuln(vuln) };
     } else {
       result[vuln.id].list.push(vuln);
     }
@@ -90,11 +90,11 @@ function mergeData(dataArray: any[]): any {
   const aggregateVulnerabilities = [].concat(...vulnsArrays);
 
   const totalUniqueCount =
-    dataArray.reduce((acc, item) => acc + item.uniqueCount || 0, 0);
+    dataArray.reduce((acc, item) => acc + item.vulnerabilities.length || 0, 0);
   const totalDepCount =
     dataArray.reduce((acc, item) => acc + item.dependencyCount || 0, 0);
 
-  const paths = dataArray.map(project => ({path: project.path, packageManager: project.packageManager}));
+  const paths = dataArray.map(project => ({ path: project.path, packageManager: project.packageManager }));
 
   return {
     vulnerabilities: aggregateVulnerabilities,
@@ -106,7 +106,14 @@ function mergeData(dataArray: any[]): any {
 }
 
 async function processData(data: any, template: string): Promise<string> {
-  const mergedData = Array.isArray(data) ? mergeData(data) : data;
+  let mergedData = {};
+  if (Array.isArray(data)) {
+    mergeData(data);
+  } else {
+    data.uniqueCount = data.vulnerabilities.length;
+    mergedData = data;
+  }
+
   return generateTemplate(mergedData, template);
 }
 

--- a/template/test-report.hbs
+++ b/template/test-report.hbs
@@ -8,53 +8,57 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>Snyk test report</title>
   <meta name="description" content="{{uniqueCount}} known vulnerabilities found in {{summary}}.">
-  <link rel="icon" type="image/png" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.png" sizes="194x194">
+  <link rel="icon" type="image/png" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.png"
+    sizes="194x194">
   <link rel="shortcut icon" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.ico">
   {{> inline-css }}
 </head>
 
 <body class="section-projects">
-<main class="layout-stacked">
+  <main class="layout-stacked">
 
-  <div class="layout-stacked__header header">
-    <header class="project__header">
-      <div class="layout-container--short">
-        <h1 class="project__header__title">Snyk test report</h1>
-        <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a"}}</p>
-        {{#if paths}}
+    <div class="layout-stacked__header header">
+      <header class="project__header">
+        <div class="layout-container--short">
+          <h1 class="project__header__title">Snyk test report</h1>
+          <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a"}}</p>
+          {{#if paths}}
           <div class="source-panel">
             <span>Scanned the following paths:</span>
             <ul>
               {{#each paths}}<li>{{path}} ({{packageManager}})</li>{{/each}}
             </ul>
           </div>
-        {{/if}}
-        {{#if path}}
+          {{/if}}
+          {{#if path}}
           <div class="source-panel">
             <span>Scanned the following path:</span>
-            <ul><li>{{path}} ({{packageManager}})</li></ul>
+            <ul>
+              <li>{{path}} ({{packageManager}})</li>
+            </ul>
           </div>
-        {{/if}}
+          {{/if}}
 
-        <div class="meta-counts">
-          <div class="meta-count"><span>{{uniqueCount}}</span> <span>known vulnerabilities</span></div>
-          <div class="meta-count"><span>{{summary}}</span></div>
-          <div class="meta-count"><span>{{dependencyCount}}</span> <span>dependencies</span></div>
-        </div><!-- .meta-counts -->
-      </div><!-- .layout-container--short -->
-    </header><!-- .project__header -->
-  </div><!-- .layout-stacked__header -->
+          <div class="meta-counts">
+            <div class="meta-count"><span>{{uniqueCount}}</span> <span>known vulnerabilities</span></div>
+            <div class="meta-count"><span>{{summary}}</span></div>
+            <div class="meta-count"><span>{{dependencyCount}}</span> <span>dependencies</span></div>
+          </div><!-- .meta-counts -->
+        </div><!-- .layout-container--short -->
+      </header><!-- .project__header -->
+    </div><!-- .layout-stacked__header -->
 
-  <div class="layout-stacked__content">
-    <div class="layout-container--short" style="padding-top: 35px;">   
-      <div class="cards--vuln filter--patch filter--ignore">
-      {{#each vulnerabilities}}
-        {{> vuln-card }}
-      {{/each}}
-      </div><!-- cards -->
-    </div>
-  </div><!-- .layout-container -->
+    <div class="layout-stacked__content">
+      <div class="layout-container--short" style="padding-top: 35px;">
+        <div class="cards--vuln filter--patch filter--ignore">
+          {{#each vulnerabilities}}
+          {{> vuln-card }}
+          {{/each}}
+        </div><!-- cards -->
+      </div>
+    </div><!-- .layout-container -->
 
-</main><!-- .layout-stacked__content -->
+  </main><!-- .layout-stacked__content -->
 </body>
+
 </html>


### PR DESCRIPTION
## Before
Counting vulnerabilities was inconsistent between multi-reports and single-reports. In the former it based it on actually counting the vulns in the data provided and in the single-reports it used the response from the API

## After
Both multi and single reports are now counting the total vulnerabilities based on the data provide

![image](https://user-images.githubusercontent.com/316371/64279566-089ba300-cf58-11e9-97de-af378a59d255.png)

## Why the change?

If a user is using `jq` to manipulate the data for a single report then the header would incorrectly show a different amount of vulns than those that were piped to it in the actual data

