### PR TITLE
chore: codeowners -> boost

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/boost


### PR DESCRIPTION
This is part of the CLI, so should be reviewed by Boost.