### PR TITLE
feat: generate es2015 code for node 6+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4856,9 +4856,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tap": "github:snyk/node-tap#alternative-runtimes",
     "ts-node": "^8.4.1",
     "tslint": "^5.20.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.3"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
     "compilerOptions": {
         "outDir": "./dist",
         "pretty": true,
-        "target": "es5",
+        "target": "es2015",
         "lib": [
-          "es2017"
+          "es2015"
         ],
         "module": "commonjs",
         "allowJs": false,


### PR DESCRIPTION
This removes some uses of tslib's promises from the generated code,
and generally cleans up stack traces and error messages.