### PR TITLE
feat: add summary option in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ First, Install the Snyk JSON to HTML Mapper using npm:
 
 Alternatively, you can skip this step, clone the repo and run the script locally (using `node ./snyk-to-html.js`)
 
+## Options of the CLI
+
+1. `-t` or `--template`-  Template location for generating the html. Defaults to template/test-report.hbs
+2. `-i` or `--input`   -  Input path from where to read the json. Defaults to stdin
+3. `-o` or `--output`  -  Output of the resulting HTML. Example: -o snyk.html. Defaults to stdout
+4. `-s` or `--summary` -  Generates an HTML with only the summary, instead of the details report. Defaults to details vulnerability report
+
+When in doubt, use `snyk-to-html --help` or `snyk-to-html -h`.
+
 ## Generate the HTML report
 
 Change directory to your package's root folder, then use of the two ways below to generate the HTML report.
@@ -34,6 +43,13 @@ Change directory to your package's root folder, then use of the two ways below t
    Pass the resulting JSON file to Snyk's JSON to HTML Mapper
 
    `snyk-to-html -i results.json -o results.html`
+
+3. By default, details about each vulnerability is shown. 
+
+    If you want a simpler version of the report to be shown, you can pass `-s` or `--summary` to only
+    display the summary of the report.
+
+    `snyk-to-html -i results.json -o results.html -s`
 
 ## View the HTML report
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,13 +159,13 @@
     "@snyk/gemfile": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@snyk/gemfile/-/gemfile-1.2.0.tgz",
-      "integrity": "sha512-nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA==",
+      "integrity": "sha1-kZhXlElzzOdMZQ5UKKrxG81cBFc=",
       "dev": true
     },
     "@snyk/ruby-semver": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@snyk/ruby-semver/-/ruby-semver-2.0.4.tgz",
-      "integrity": "sha512-ceMD4CBS3qtAg+O0BUvkKdsheUNCqi+/+Rju243Ul8PsUgZnXmGiqfk/2z7DCprRQnxUTra4+IyeDQT7wAheCQ==",
+      "integrity": "sha1-RXaG6npNYLEO/d3plYfvs6U7qIQ=",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"
@@ -187,7 +187,7 @@
         "@snyk/cli-interface": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-1.5.0.tgz",
-          "integrity": "sha512-+Qo+IO3YOXWgazlo+CKxOuWFLQQdaNCJ9cSfhFQd687/FuesaIxWdInaAdfpsLScq0c6M1ieZslXgiZELSzxbg==",
+          "integrity": "sha1-udvm6/uG5n/6vynU4NKKUmcKxFY=",
           "dev": true,
           "requires": {
             "tslib": "^1.9.3"
@@ -212,7 +212,7 @@
     "@types/agent-base": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-8mrhPstU+ZX0Ugya8tl5DsDZ1I5ZwQzbL/8PA0z8Gj0k9nql7nkaMzmPVLj+l/nixWaliXi+EBiLA8bptw3z7Q==",
+      "integrity": "sha1-AGROizlbQOG/UKrx0iyrwSANUFE=",
       "dev": true,
       "requires": {
         "@types/events": "*",
@@ -222,7 +222,7 @@
     "@types/bunyan": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.6.tgz",
-      "integrity": "sha512-YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==",
+      "integrity": "sha1-ZSdkHMowvt7F/rmrUnt4A7gABYI=",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -231,43 +231,37 @@
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+      "integrity": "sha1-sU76iFK3do2JiQZhPCP2iHE+As0=",
       "dev": true
     },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
       "dev": true
     },
     "@types/js-yaml": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==",
+      "integrity": "sha1-XG9KHqvKhHkvvZFvDLQIR/EjxlY=",
       "dev": true
     },
     "@types/marked": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.6.5.tgz",
-      "integrity": "sha512-6kBKf64aVfx93UJrcyEZ+OBM5nGv4RLsI6sR1Ar34bpgvGVRoyTgpxn4ZmtxOM5aDTAaaznYuYUH8bUX3Nk3YA==",
-      "dev": true
-    },
-    "@types/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "integrity": "sha1-PPKlbvYV2tJKr5l4TvkKnrpOKdg=",
       "dev": true
     },
     "@types/node": {
-      "version": "6.14.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.7.tgz",
-      "integrity": "sha512-YbPXbaynBTe0pVExPhL76TsWnxSPeFAvImIsmylpBWn/yfw+lHy+Q68aawvZHsgskT44ZAoeE67GM5f+Brekew==",
+      "version": "6.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.9.tgz",
+      "integrity": "sha512-leP/gxHunuazPdZaCvsCefPQxinqUDsCxCR5xaDUrY2MkYxQRFZZwU5e7GojyYsGB7QVtCi7iVEl/hoFXQYc+w==",
       "dev": true
     },
     "@types/restify": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/@types/restify/-/restify-4.3.6.tgz",
-      "integrity": "sha512-4l4f0EXnleXQttlhRCXtTuJ8UelsKiAKIK2AAEd2epBHu41aEbM0U2z6E5tUrNwlbxz7qaNBISduGMeg+G3PaA==",
+      "integrity": "sha1-XaWIm2XDTDOTemdoa6tZEyXd6AY=",
       "dev": true,
       "requires": {
         "@types/bunyan": "*",
@@ -277,13 +271,13 @@
     "@types/semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+      "integrity": "sha1-FGwqKe59O65L8vyydGNuJkyBPEU=",
       "dev": true
     },
     "@types/xml2js": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz",
-      "integrity": "sha512-Pv2HGRE4gWLs31In7nsyXEH4uVVsd0HNV9i2dyASvtDIlOtSTr1eczPLDpdEuyv5LWH5LT20GIXwPjkshKWI1g==",
+      "integrity": "sha1-L0G/x01aQCJRFyH4cu05WiEK07c=",
       "dev": true,
       "requires": {
         "@types/events": "*",
@@ -293,19 +287,19 @@
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "integrity": "sha1-53qX+9NFt22DJF7c0X05OxtB+zE=",
       "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -326,7 +320,7 @@
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
       "dev": true
     },
     "ansi-regex": {
@@ -338,7 +332,7 @@
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
@@ -365,7 +359,7 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -380,7 +374,7 @@
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -434,7 +428,7 @@
     "bind-obj-methods": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz",
-      "integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw==",
+      "integrity": "sha1-AXgUDb57e7Z9x0iSrOWbwCR/BvA=",
       "dev": true
     },
     "bluebird": {
@@ -446,7 +440,7 @@
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
       "dev": true,
       "requires": {
         "ansi-align": "^2.0.0",
@@ -469,7 +463,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -479,7 +473,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -496,7 +490,7 @@
     "capture-stack-trace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+      "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10=",
       "dev": true
     },
     "caseless": {
@@ -508,7 +502,7 @@
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -519,13 +513,13 @@
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
       "dev": true
     },
     "ci-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
       "dev": true
     },
     "clean-yaml-object": {
@@ -619,7 +613,7 @@
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -634,23 +628,22 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+      "integrity": "sha1-VFmDoGA/5CW8Zy1myePInEISGoM="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -661,7 +654,7 @@
     "configstore": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
       "dev": true,
       "requires": {
         "dot-prop": "^4.1.0",
@@ -750,7 +743,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
       "dev": true
     },
     "define-properties": {
@@ -777,7 +770,7 @@
     "dockerfile-ast": {
       "version": "0.0.16",
       "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.16.tgz",
-      "integrity": "sha512-+HZToHjjiLPl46TqBrok5dMrg5oCkZFPSROMQjRmvin0zG4FxK0DJXTpV/CUPYY2zpmEvVza55XLwSHFx/xZMw==",
+      "integrity": "sha1-ELMp00Mynasd5wN1gzSV+FrWWRM=",
       "dev": true,
       "requires": {
         "vscode-languageserver-types": "^3.5.0"
@@ -786,7 +779,7 @@
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
@@ -808,7 +801,7 @@
         "xml2js": {
           "version": "0.4.19",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+          "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
           "dev": true,
           "requires": {
             "sax": ">=0.6.0",
@@ -836,19 +829,19 @@
     "email-validator": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
-      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+      "integrity": "sha1-uN+qXQ2uKPGwPJWIHZBNTkC/5+0=",
       "dev": true
     },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
       "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -892,13 +885,13 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
     "events-to-array": {
@@ -910,7 +903,7 @@
     "execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
@@ -946,13 +939,13 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true
     },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
       "dev": true,
       "requires": {
         "chardet": "^0.7.0",
@@ -1021,7 +1014,7 @@
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
@@ -1050,13 +1043,13 @@
     "function-loop": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.2.tgz",
-      "integrity": "sha512-Iw4MzMfS3udk/rqxTiDDCllhGwlOrsr50zViTOO/W6lS/9y6B1J0BD2VZzrnWUYBJsl3aeqjgR5v7bWWhZSYbA==",
+      "integrity": "sha1-Frk911eEXqz+yhqAYaamXBBuDLI=",
       "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
@@ -1074,7 +1067,7 @@
     "git-up": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
-      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "integrity": "sha1-yy7whmU2QOch0gQv4xBIV9iQB8A=",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -1084,7 +1077,7 @@
     "git-url-parse": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
-      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "integrity": "sha1-r/Gol8NsyTaZJwWHvqPby7uV3mc=",
       "dev": true,
       "requires": {
         "git-up": "^4.0.0"
@@ -1116,7 +1109,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true
     },
     "got": {
@@ -1194,7 +1187,7 @@
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "dev": true,
       "requires": {
         "ajv": "^6.5.5",
@@ -1225,7 +1218,7 @@
     "hosted-git-info": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+      "integrity": "sha1-dZz88sTRVq3lmwst+r3cQqa5xww=",
       "dev": true
     },
     "http-signature": {
@@ -1242,7 +1235,7 @@
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -1279,19 +1272,19 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
       "dev": true
     },
     "inquirer": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -1335,7 +1328,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-callable": {
@@ -1347,7 +1340,7 @@
     "is-ci": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
       "dev": true,
       "requires": {
         "ci-info": "^1.5.0"
@@ -1405,7 +1398,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -1435,13 +1428,13 @@
     "is-retry-allowed": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "integrity": "sha1-13hIi9CkZmo76KFIK58rqv7eqLQ=",
       "dev": true
     },
     "is-ssh": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
-      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "integrity": "sha1-80moyt0k5lKYA3pSLPdSDy6BoPM=",
       "dev": true,
       "requires": {
         "protocols": "^1.1.0"
@@ -1501,13 +1494,13 @@
     "istanbul-lib-coverage": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+      "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
       "dev": true
     },
     "istanbul-lib-instrument": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.4.0",
@@ -1530,13 +1523,13 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1552,7 +1545,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-schema": {
@@ -1564,7 +1557,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json-stringify-safe": {
@@ -1588,7 +1581,7 @@
     "jszip": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
-      "integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
+      "integrity": "sha1-sUOBbffhBqlZepTHdJM4WtylvR0=",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -1639,7 +1632,7 @@
     "lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
       "dev": true,
       "requires": {
         "immediate": "~3.0.5"
@@ -1648,7 +1641,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
       "dev": true
     },
     "lodash.assign": {
@@ -1696,13 +1689,13 @@
     "log-driver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "integrity": "sha1-Y7lQIfBwL+36LJuwok53l9cYcdg=",
       "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
       "dev": true
     },
     "lru-cache": {
@@ -1718,13 +1711,13 @@
     "macos-release": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+      "integrity": "sha1-6xkwsDbAgArevM1fF7xMEt6Ltx8=",
       "dev": true
     },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
       "dev": true,
       "requires": {
         "pify": "^3.0.0"
@@ -1733,13 +1726,13 @@
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "integrity": "sha1-7+ToH22yjK3WBccPKcgxtY73dsg=",
       "dev": true
     },
     "marked": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+      "integrity": "sha1-tkIB8FHScbHtwQoE0a6bdLuOXA4="
     },
     "mime-db": {
       "version": "1.40.0",
@@ -1759,13 +1752,13 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -1774,12 +1767,13 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "minipass": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "integrity": "sha1-5xN2Ln0+Mv7YAxFc+T4EvKn8yaY=",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
@@ -1832,12 +1826,12 @@
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "integrity": "sha1-DQVdU/UFKqZTyfbraLtdEr9cK1s="
     },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "mute-stream": {
@@ -1849,7 +1843,7 @@
     "nconf": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-      "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+      "integrity": "sha1-2hKF7pXQqSLKbO51rc+GH0ggWtI=",
       "dev": true,
       "requires": {
         "async": "^1.4.0",
@@ -1861,7 +1855,7 @@
     "needle": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "integrity": "sha1-aDPnSXXERGQlkOFadQKIxfk5tXw=",
       "dev": true,
       "requires": {
         "debug": "^3.2.6",
@@ -1883,18 +1877,18 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw="
     },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
     "normalize-url": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+      "integrity": "sha1-suHE3E98bVd0PfczpPWXjRhlBVk=",
       "dev": true
     },
     "npm-run-path": {
@@ -1915,7 +1909,7 @@
     "nyc": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
-      "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
+      "integrity": "sha1-2k2+kanIuerT9PM0THbzU+PHjHU=",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
@@ -2949,13 +2943,13 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true
     },
     "object-hash": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+      "integrity": "sha1-/eRSCYqVHLFF8Dm7fUVUSd3BJt8=",
       "dev": true
     },
     "object-inspect": {
@@ -3001,13 +2995,13 @@
     "opener": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+      "integrity": "sha1-bS8Od/GgrwAyrKcWwsH7uOfoq+0=",
       "dev": true
     },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+      "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
@@ -3047,7 +3041,7 @@
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
-      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "integrity": "sha1-3sGdlmKW4c1i1wGlpm7h3ernCAE=",
       "dev": true,
       "requires": {
         "macos-release": "^2.2.0",
@@ -3069,7 +3063,7 @@
     "own-or-env": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
-      "integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
+      "integrity": "sha1-VM5gHTv3gjbFxlYzqhyOwD+AB+Q=",
       "dev": true,
       "requires": {
         "own-or": "^1.0.0"
@@ -3096,7 +3090,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
@@ -3104,13 +3098,13 @@
     "pako": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "integrity": "sha1-Qyi621CGpCaqkPVBl31JVdpclzI=",
       "dev": true
     },
     "parse-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
-      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "integrity": "sha1-DsdpcElJd4yzuO2l6ZTDIHOhrf8=",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -3120,7 +3114,7 @@
     "parse-url": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
-      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "integrity": "sha1-mcQIT8Eb4UFB76QbPRF6lvy5Un8=",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -3150,7 +3144,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
       "dev": true
     },
     "performance-now": {
@@ -3174,13 +3168,13 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true
     },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "dev": true,
       "requires": {
         "asap": "~2.0.3"
@@ -3189,7 +3183,7 @@
     "protocols": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+      "integrity": "sha1-lfeIpPDpebKR/+/PVjatET0DfTI=",
       "dev": true
     },
     "pseudomap": {
@@ -3207,7 +3201,7 @@
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -3217,19 +3211,19 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
       "dev": true
     },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
@@ -3264,7 +3258,7 @@
     "registry-auth-token": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
       "dev": true,
       "requires": {
         "rc": "^1.1.6",
@@ -3283,7 +3277,7 @@
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -3330,7 +3324,7 @@
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -3363,13 +3357,13 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "secure-keys": {
@@ -3381,7 +3375,7 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
       "dev": true
     },
     "semver-diff": {
@@ -3396,7 +3390,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
@@ -4040,7 +4034,7 @@
     "snyk-config": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-2.2.3.tgz",
-      "integrity": "sha512-9NjxHVMd1U1LFw66Lya4LXgrsFUiuRiL4opxfTFo0LmMNzUoU5Bk/p0zDdg3FE5Wg61r4fP2D8w+QTl6M8CGiw==",
+      "integrity": "sha1-jgm7mGAq0ESVTTCp/BaVq1tgQvo=",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
@@ -4074,7 +4068,7 @@
     "snyk-go-parser": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.3.1.tgz",
-      "integrity": "sha512-jrFRfIk6yGHFeipGD66WV9ei/A/w/lIiGqI80w1ndMbg6D6M5pVNbK7ngDTmo4GdHrZDYqx/VBGBsUm2bol3Rg==",
+      "integrity": "sha1-QnOHUHV4uvAIo+c4KODlPtjHlvM=",
       "dev": true,
       "requires": {
         "toml": "^3.0.0",
@@ -4084,7 +4078,7 @@
     "snyk-go-plugin": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.11.1.tgz",
-      "integrity": "sha512-IsNi7TmpHoRHzONOWJTT8+VYozQJnaJpKgnYNQjzNm2JlV8bDGbdGQ1a8LcEoChxnJ8v8aMZy7GTiQyGGABtEQ==",
+      "integrity": "sha1-zXxzxCvTz1+qKpClTNfG25Jv6l0=",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -4112,7 +4106,7 @@
     "snyk-module": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/snyk-module/-/snyk-module-1.9.1.tgz",
-      "integrity": "sha512-A+CCyBSa4IKok5uEhqT+hV/35RO6APFNLqk9DRRHg7xW2/j//nPX8wTSZUPF8QeRNEk/sX+6df7M1y6PBHGSHA==",
+      "integrity": "sha1-sqePc2YAsKtoDxcDRm7XMJyYCAQ=",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
@@ -4143,7 +4137,7 @@
         "tslib": {
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+          "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY=",
           "dev": true
         }
       }
@@ -4191,7 +4185,7 @@
     "snyk-paket-parser": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/snyk-paket-parser/-/snyk-paket-parser-1.5.0.tgz",
-      "integrity": "sha512-1CYMPChJ9D9LBy3NLqHyv8TY7pR/LMISSr08LhfFw/FpfRZ+gTH8W6bbxCmybAYrOFNCqZkRprqOYDqZQFHipA==",
+      "integrity": "sha1-oOloiNnTBLGuYgOgNplxV18JlUg=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.3"
@@ -4210,7 +4204,7 @@
         "tslib": {
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+          "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY=",
           "dev": true
         }
       }
@@ -4218,7 +4212,7 @@
     "snyk-policy": {
       "version": "1.13.5",
       "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.13.5.tgz",
-      "integrity": "sha512-KI6GHt+Oj4fYKiCp7duhseUj5YhyL/zJOrrJg0u6r59Ux9w8gmkUYT92FHW27ihwuT6IPzdGNEuy06Yv2C9WaQ==",
+      "integrity": "sha1-xc8mL3WYeaZasIEN1Y1ZyOx+nkc=",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
@@ -4256,7 +4250,7 @@
     "snyk-resolve": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/snyk-resolve/-/snyk-resolve-1.0.1.tgz",
-      "integrity": "sha512-7+i+LLhtBo1Pkth01xv+RYJU8a67zmJ8WFFPvSxyCjdlKIcsps4hPQFebhz+0gC5rMemlaeIV6cqwqUf9PEDpw==",
+      "integrity": "sha1-6qSidc9+K1efGNpbGI/mAbju2as=",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
@@ -4277,7 +4271,7 @@
     "snyk-resolve-deps": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-4.4.0.tgz",
-      "integrity": "sha512-aFPtN8WLqIk4E1ulMyzvV5reY1Iksz+3oPnUVib1jKdyTHymmOIYF7z8QZ4UUr52UsgmrD9EA/dq7jpytwFoOQ==",
+      "integrity": "sha1-7yD7V4pMkgzCYvtz3Skv8hIV9S0=",
       "dev": true,
       "requires": {
         "@types/node": "^6.14.4",
@@ -4311,7 +4305,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
@@ -4331,7 +4325,7 @@
         "tmp": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "integrity": "sha1-7kNKTiJUMILilLpiAdzG6v76KHc=",
           "dev": true,
           "requires": {
             "rimraf": "^2.6.3"
@@ -4380,7 +4374,7 @@
     "source-map-support": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "integrity": "sha1-CuBp5/47p1OMZMmFFeNTOerFoEI=",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -4402,7 +4396,7 @@
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -4419,13 +4413,13 @@
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+      "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
       "dev": true
     },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -4510,7 +4504,7 @@
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
@@ -4573,7 +4567,7 @@
     "tap-mocha-reporter": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.9.tgz",
-      "integrity": "sha512-VO07vhC9EG27EZdOe7bWBj1ldbK+DL9TnRadOgdQmiQOVZjFpUEQuuqO7+rNSO2kfmkq5hWeluYXDWNG/ytXTQ==",
+      "integrity": "sha1-6kHnQRSalMJ40QbLzMw3/sLf7qo=",
       "dev": true,
       "requires": {
         "color-support": "^1.1.0",
@@ -4590,7 +4584,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4605,7 +4599,7 @@
         "tap-parser": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
-          "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
+          "integrity": "sha1-aQfolyXXt/pq5B7ixGTD20MYiuw=",
           "dev": true,
           "requires": {
             "events-to-array": "^1.0.1",
@@ -4618,7 +4612,7 @@
     "tap-parser": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
-      "integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
+      "integrity": "sha1-VNs1MC/aLCzMIZVK074issukJyE=",
       "dev": true,
       "requires": {
         "events-to-array": "^1.0.1",
@@ -4709,13 +4703,13 @@
     "tmatch": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-4.0.0.tgz",
-      "integrity": "sha512-Ynn2Gsp+oCvYScQXeV+cCs7citRDilq0qDXA6tuvFwDgiYyyaq7D5vKUlAPezzZR5NDobc/QMeN6e5guOYmvxg==",
+      "integrity": "sha1-uheAB/ML9qcPN8ZD/KUEX7L4xEg=",
       "dev": true
     },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
@@ -4730,13 +4724,13 @@
     "toml": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "integrity": "sha1-NCFg8a8ZBOydIE0DpdYSItdixe4=",
       "dev": true
     },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
       "dev": true,
       "requires": {
         "psl": "^1.1.24",
@@ -4787,13 +4781,13 @@
     "tsame": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/tsame/-/tsame-2.0.1.tgz",
-      "integrity": "sha512-jxyxgKVKa4Bh5dPcO42TJL22lIvfd9LOVJwdovKOnJa4TLLrHxquK+DlGm4rkGmrcur+GRx+x4oW00O2pY/fFw==",
+      "integrity": "sha1-cEEN2+/NKcYeLWhUmzNHsERNYT8=",
       "dev": true
     },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo=",
       "dev": true
     },
     "tslint": {
@@ -4817,6 +4811,12 @@
         "tsutils": "^2.29.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+          "dev": true
+        },
         "diff": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -4826,7 +4826,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
@@ -4834,7 +4834,7 @@
     "tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -4874,7 +4874,7 @@
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
           "optional": true
         },
         "source-map": {
@@ -4921,7 +4921,7 @@
     "update-notifier": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
       "dev": true,
       "requires": {
         "boxen": "^1.2.1",
@@ -4939,7 +4939,7 @@
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -4973,7 +4973,7 @@
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
       "dev": true
     },
     "verror": {
@@ -4990,13 +4990,13 @@
     "vscode-languageserver-types": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==",
+      "integrity": "sha1-07WVIkbTDlJBWStt3oKA4DlC50M=",
       "dev": true
     },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -5005,7 +5005,7 @@
     "widest-line": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"
@@ -5020,7 +5020,7 @@
     "windows-release": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
-      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "integrity": "sha1-gSLa1a/DA9gzQiOAaAp5zfqReF8=",
       "dev": true,
       "requires": {
         "execa": "^1.0.0"
@@ -5034,7 +5034,7 @@
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -5051,7 +5051,7 @@
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -5079,7 +5079,7 @@
     "write-file-atomic": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -5107,7 +5107,7 @@
         "xmlbuilder": {
           "version": "11.0.1",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-          "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+          "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "commander": "^4.1.0",
     "handlebars": "^4.5.3",
     "marked": "^0.7.0",
-    "minimist": "^1.2.0",
     "moment": "^2.24.0",
     "source-map-support": "^0.5.16"
   },
@@ -32,7 +32,6 @@
   "snyk": true,
   "devDependencies": {
     "@types/marked": "^0.6.5",
-    "@types/minimist": "^1.2.0",
     "@types/node": "^6.14.7",
     "snyk": "^1.235.0",
     "tap": "github:snyk/node-tap#alternative-runtimes",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,38 +1,43 @@
 #!/usr/bin/env node
 
+import program = require('commander');
 import fs = require('fs');
-import minimist = require('minimist');
 import path = require('path');
-import { SnykToHtml } from './lib/snyk-to-html';
+import {SnykToHtml} from './lib/snyk-to-html';
 
-const argv = minimist(process.argv.slice(2));
+program
+.option('-t, --template <path>', 'Template location for generating the html. Defaults to template/test-report.hbs')
+.option('-i, --input <path>', 'Input path from where to read the json. Defaults to stdin')
+.option('-o, --output <path>', 'Output of the resulting HTML. Example: -o snyk.html. Defaults to stdout')
+.option('-s, --summary', 'Generates an HTML with only the summary, instead of the details report')
+.parse(process.argv);
 
 let template;
 let source;
 let output;
 
-if (argv.t) { // template
-  template = argv.t; // grab the next item
+if (program.template) { // template
+  template = program.template; // grab the next item
   if (typeof template === 'boolean') {
     template = path.join(__dirname, '../template/test-report.hbs');
   }
 } else {
   template = path.join(__dirname, '../template/test-report.hbs');
 }
-if (argv.i) { // input source
-  source = argv.i; // grab the next item
+if (program.input) { // input source
+  source = program.input; // grab the next item
   if (typeof source === 'boolean') {
     source = undefined;
   }
 }
-if (argv.o) { // output destination
-  output = argv.o; // grab the next item
+if (program.output) { // output destination
+  output = program.output; // grab the next item
   if (typeof output === 'boolean') {
     output = undefined;
   }
 }
 
-SnykToHtml.run(source, template, onReportOutput);
+SnykToHtml.run(source, template, !!program.summary, onReportOutput);
 
 function onReportOutput(report: string): void {
   if (output) {

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -6,31 +6,36 @@ import marked = require('marked');
 import moment = require('moment');
 import path = require('path');
 
-const severityMap = { low: 0, medium: 1, high: 2 };
+const severityMap = {low: 0, medium: 1, high: 2};
+const defaultRemediationText = '## Remediation\nThere is no remediation at the moment';
 
 function readFile(filePath: string, encoding: string): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     fs.readFile(filePath, encoding, (err, data) => {
-      if (err) { reject(err); }
+      if (err) {
+        reject(err);
+      }
       resolve(data);
     });
   });
 }
 
 class SnykToHtml {
-  public static run(dataSource: string, hbsTemplate: string, reportCallback: (value: string) => void): void {
+  public static run(dataSource: string,
+                    hbsTemplate: string,
+                    summary: boolean,
+                    reportCallback: (value: string) => void): void {
     SnykToHtml
-      .runAsync(dataSource, hbsTemplate)
+      .runAsync(dataSource, hbsTemplate, summary)
       .then(reportCallback)
       .catch(console.log);
   }
 
-  public static async runAsync(source: string, template: string): Promise<string> {
+  public static async runAsync(source: string, template: string, summary: boolean): Promise<string> {
     const promisedString = source ? readFile(source, 'utf8') : readInputFromStdin();
-    const report = promisedString
+    return promisedString
       .then(JSON.parse)
-      .then(data => processData(data, template));
-    return report;
+      .then(data => processData(data, template, summary));
   }
 }
 
@@ -45,6 +50,7 @@ function metadataForVuln(vuln: any) {
     severity: vuln.severity,
     severityValue: severityMap[vuln.severity],
     description: vuln.description || 'No description available.',
+    fixedIn: vuln.fixedIn,
     packageManager: vuln.packageManager,
   };
 }
@@ -57,7 +63,7 @@ function groupVulns(vulns) {
   if (vulns && Array.isArray(vulns)) {
     vulns.map(vuln => {
       if (!result[vuln.id]) {
-        result[vuln.id] = { list: [vuln], metadata: metadataForVuln(vuln) };
+        result[vuln.id] = {list: [vuln], metadata: metadataForVuln(vuln)};
         pathsCount++;
         uniqueCount++;
       } else {
@@ -85,11 +91,12 @@ async function registerPeerPartial(templatePath: string, name: string): Promise<
   Handlebars.registerPartial(name, template);
 }
 
-async function generateTemplate(data: any, template: string): Promise<string> {
+async function generateTemplate(data: any, template: string, summary: boolean): Promise<string> {
   const vulnMetadata = groupVulns(data.vulnerabilities);
   data.vulnerabilities = vulnMetadata.vulnerabilities;
   data.uniqueCount = vulnMetadata.vulnerabilitiesUniqueCount;
   data.summary = vulnMetadata.vulnerabilitiesPathsCount + ' vulnerable dependency paths';
+  data.showSummaryOnly = summary;
 
   await registerPeerPartial(template, 'inline-css');
   await registerPeerPartial(template, 'vuln-card');
@@ -118,9 +125,9 @@ function mergeData(dataArray: any[]): any {
   };
 }
 
-async function processData(data: any, template: string): Promise<string> {
+async function processData(data: any, template: string, summary: boolean): Promise<string> {
   const mergedData = Array.isArray(data) ? mergeData(data) : data;
-  return generateTemplate(mergedData, template);
+  return generateTemplate(mergedData, template, summary);
 }
 
 async function readInputFromStdin(): Promise<string> {
@@ -170,6 +177,22 @@ const hh = {
       case '||': return choose(v1 || v2);
       default: return choose(false);
     }
+  },
+  getRemediation: function(description, fixedIn) {
+    // check remediation in the description
+    const index = description.indexOf('## Remediation');
+    if (index > -1) {
+      return marked(description.substring(index));
+    }
+    // if no remediation in description, try to check in `fixedIn` attribute
+    if (Array.isArray(fixedIn) && fixedIn.length) {
+      const fixedInJoined = fixedIn.join(', ');
+      return marked(`## Remediation\n Fixed in: ${fixedInJoined}`);
+    }
+
+    // otherwise, fallback to default message, i.e. No remediation at the moment
+    return marked(defaultRemediationText);
+
   },
 };
 

--- a/template/test-report.hbs
+++ b/template/test-report.hbs
@@ -20,7 +20,12 @@
     <div class="layout-stacked__header header">
       <header class="project__header">
         <div class="layout-container--short">
-          <h1 class="project__header__title">Snyk test report</h1>
+          {{#unless showSummaryOnly}}
+            <h1 class="project__header__title">Snyk test report</h1>
+          {{else}}
+            <h1 class="project__header__title">Snyk test summary</h1>
+          {{/unless}}
+
           <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a"}}</p>
           {{#if paths}}
           <div class="source-panel">
@@ -52,7 +57,7 @@
       <div class="layout-container--short" style="padding-top: 35px;">
         <div class="cards--vuln filter--patch filter--ignore">
           {{#each vulnerabilities}}
-          {{> vuln-card }}
+          {{> vuln-card showSummaryOnly=../showSummaryOnly}}
           {{/each}}
         </div><!-- cards -->
       </div>

--- a/template/test-report.vuln-card.hbs
+++ b/template/test-report.vuln-card.hbs
@@ -70,77 +70,83 @@
 
         <hr/>
 
-        {{#if_eq @root.project.type "npm"}}
-            <h3 class="card__section__title">Detailed paths and remediation</h3>
-        {{else}}
-            <h3 class="card__section__title">Detailed paths</h3>
-        {{/if_eq}}
+        {{#unless showSummaryOnly}}
 
-        <ul class="card__meta__paths">
-            {{#each list}}
-                {{#isDoubleArray from}}
-                    {{#each .}}
-                    <li class="list-paths__item">
+            {{#if_eq @root.project.type "npm"}}
+                <h3 class="card__section__title">Detailed paths and remediation</h3>
+            {{else}}
+                <h3 class="card__section__title">Detailed paths</h3>
+            {{/if_eq}}
+
+            <ul class="card__meta__paths">
+                {{#each list}}
+                    {{#isDoubleArray from}}
+                        {{#each .}}
+                        <li class="list-paths__item">
+                            <span class="list-paths__item__introduced"><em>Introduced through</em>:
+                                {{#each .}}
+                                    {{.}}
+                                    {{#unless @last}} <span class="list-paths__item__arrow">›</span> {{/unless}}
+                                {{/each}}
+                            </span>
+                        {{/each}}
+                    {{else}}
+                        <li>
                         <span class="list-paths__item__introduced"><em>Introduced through</em>:
                             {{#each .}}
                                 {{.}}
                                 {{#unless @last}} <span class="list-paths__item__arrow">›</span> {{/unless}}
                             {{/each}}
                         </span>
-                    {{/each}}
-                {{else}}
-                    <li>
-                    <span class="list-paths__item__introduced"><em>Introduced through</em>:
-                        {{#each .}}
-                            {{.}}
-                            {{#unless @last}} <span class="list-paths__item__arrow">›</span> {{/unless}}
-                        {{/each}}
-                    </span>
-                {{/isDoubleArray}}
+                    {{/isDoubleArray}}
 
-                {{#if_eq @root.project.type "npm"}}
-                    <span class="list-paths__item__remediation">
-                    <strong>Remediation:</strong>
-                    {{#if_any isUpgradable isPatchable}}
-                        {{#upgradeAvailable upgradePath}}{{!-- Direct dependency with upgrade. --}}
-                            {{#if_eq upgradePath.[1] from.[1]}}{{!-- Dependencies are out of date. --}}
-                                Your dependencies are out of date, otherwise you would be using a newer {{name}} than {{name}}@{{version}}.
-                                Try deleting node_modules, reinstalling and running <code><a href="/docs/using-snyk/#wizard">snyk wizard</a></code>.
-                                If the problem persists, one of your dependencies may be bundling outdated modules.
-                            {{else}}{{!-- Dependencies are not out of date. --}}
-                                Upgrade to {{#firstNonFalse upgradePath}}{{.}}{{/firstNonFalse}}.
-                            {{/if_eq}}
-                            {{else}}{{!-- This is not a direct dependency, but there is an upgrade --}}
-                            {{#if patches}}{{!-- There are patches --}}
-                                Run <code><a href="/docs/using-snyk/#wizard">snyk wizard</a></code> to patch {{name}}@{{version}}.
-                            {{else}}{{!-- There are no patches --}}
-                                {{#if @root.isTest}}{{!-- This is a test page --}}
-                                No direct dependency upgrade can address this issue.
-                                If possible, manually upgrade to {{#firstNonFalse upgradePath}}{{.}}{{/firstNonFalse}},
-                                or run <code><a href="/docs/using-snyk/#monitor">snyk monitor</a></code> to get notified when an easier upgrade or a patch becomes available.
-                                {{else}}{{!-- This is a monitor page --}}
-                                No direct dependency upgrade can address this issue.
-                                If possible, manually upgrade to {{#firstNonFalse upgradePath}}{{.}}{{/firstNonFalse}}.
-                                We'll notify you when an easier upgrade or a patch is available.
+                    {{#if_eq @root.project.type "npm"}}
+                        <span class="list-paths__item__remediation">
+                        <strong>Remediation:</strong>
+                        {{#if_any isUpgradable isPatchable}}
+                            {{#upgradeAvailable upgradePath}}{{!-- Direct dependency with upgrade. --}}
+                                {{#if_eq upgradePath.[1] from.[1]}}{{!-- Dependencies are out of date. --}}
+                                    Your dependencies are out of date, otherwise you would be using a newer {{name}} than {{name}}@{{version}}.
+                                    Try deleting node_modules, reinstalling and running <code><a href="/docs/using-snyk/#wizard">snyk wizard</a></code>.
+                                    If the problem persists, one of your dependencies may be bundling outdated modules.
+                                {{else}}{{!-- Dependencies are not out of date. --}}
+                                    Upgrade to {{#firstNonFalse upgradePath}}{{.}}{{/firstNonFalse}}.
+                                {{/if_eq}}
+                                {{else}}{{!-- This is not a direct dependency, but there is an upgrade --}}
+                                {{#if patches}}{{!-- There are patches --}}
+                                    Run <code><a href="/docs/using-snyk/#wizard">snyk wizard</a></code> to patch {{name}}@{{version}}.
+                                {{else}}{{!-- There are no patches --}}
+                                    {{#if @root.isTest}}{{!-- This is a test page --}}
+                                    No direct dependency upgrade can address this issue.
+                                    If possible, manually upgrade to {{#firstNonFalse upgradePath}}{{.}}{{/firstNonFalse}},
+                                    or run <code><a href="/docs/using-snyk/#monitor">snyk monitor</a></code> to get notified when an easier upgrade or a patch becomes available.
+                                    {{else}}{{!-- This is a monitor page --}}
+                                    No direct dependency upgrade can address this issue.
+                                    If possible, manually upgrade to {{#firstNonFalse upgradePath}}{{.}}{{/firstNonFalse}}.
+                                    We'll notify you when an easier upgrade or a patch is available.
+                                    {{/if}}
                                 {{/if}}
-                            {{/if}}
-                        {{/upgradeAvailable}}
-                    {{else}}{{!-- There are no upgrades or patches --}}
-                        No remediation path available.
-                    {{/if_any}}
-                    </span><!-- .list-paths__item__remediation -->
-                {{/if_eq}}
-                </li>
-                </li>
-            {{/each}}
-        </ul><!-- .list-paths -->
+                            {{/upgradeAvailable}}
+                        {{else}}{{!-- There are no upgrades or patches --}}
+                            No remediation path available.
+                        {{/if_any}}
+                        </span><!-- .list-paths__item__remediation -->
+                    {{/if_eq}}
+                    </li>
+                {{/each}}
+            </ul><!-- .list-paths -->
+        {{/unless}}
 
     </div><!-- .card__section -->
 
-    <hr/>
-    <!-- Overview -->
-    {{{markdown metadata.description}}}
-    <hr/>
+    {{#unless showSummaryOnly}}
+      <hr/>
+      <!-- Overview -->
+      {{{markdown metadata.description}}}
+      <hr/>
+    {{else}}
+      {{{getRemediation metadata.description metadata.fixedIn}}}
+    {{/unless}}
 
     <div class="cta card__cta">
         <p><a href="https://snyk.io/vuln/{{metadata.id}}">More about this vulnerability</a></p>

--- a/test/fixtures/test-report-with-no-remediation-and-no-fixed-in.json
+++ b/test/fixtures/test-report-with-no-remediation-and-no-fixed-in.json
@@ -1,0 +1,80 @@
+{
+  "ok": false,
+  "vulnerabilities": [
+    {
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "credit": [
+        "kamael"
+      ],
+      "moduleName": "brace-expansion",
+      "packageName": "brace-expansion",
+      "language": "js",
+      "packageManager": "npm",
+      "description": "## Overview\n[`brace-expansion`](https://www.npmjs.com/package/brace-expansion) is a package that performs brace expansion as known from sh/bash.\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.\nRunning:\n```js\nconst expand = require('brace-expansion');\nexpand('{,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,\\n}')\n```\nWill hang for long periods of time.\n\n## Details\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack.  Many Regular Expression implementations may reach edge cases that causes them to work very slowly (exponentially related to input size), allowing an attacker to exploit this and can cause the program to enter these extreme situations by using a Regex string and cause the service to hang for a large periods of time.\n\nYou can read more about `Regular Expression Denial of Service (ReDoS)` on our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\n\n",
+      "identifiers": {
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "NSP": 338,
+        "ALTERNATIVE": [
+          "SNYK-JS-BRACEEXPANSION-10483"
+        ]
+      },
+      "semver": {
+        "unaffected": ">=1.1.7",
+        "vulnerable": "<1.1.7"
+      },
+      "patches": [],
+      "severity": "medium",
+      "CVSSv3": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "disclosureTime": "2017-03-01T22:00:00.000Z",
+      "publicationTime": "2017-04-26T09:19:21.663Z",
+      "modificationTime": "2017-04-26T09:19:21.663Z",
+      "creationTime": "2017-04-26T09:19:21.663Z",
+      "id": "npm:brace-expansion:20170302",
+      "alternativeIds": [
+        "SNYK-JS-BRACEEXPANSION-10483"
+      ],
+      "from": [
+        "goof@0.0.3",
+        "tap@5.8.0",
+        "nyc@6.6.1",
+        "glob@7.0.3",
+        "minimatch@3.0.0",
+        "brace-expansion@1.1.4"
+      ],
+      "upgradePath": [
+        false,
+        "tap@5.8.0",
+        "nyc@6.6.1",
+        "glob@7.0.3",
+        "minimatch@3.0.0",
+        "brace-expansion@1.1.7"
+      ],
+      "version": "1.1.4",
+      "name": "brace-expansion",
+      "isUpgradable": true,
+      "isPatchable": false,
+      "__filename": "/Users/dror/work/repos/snyk/goof/node_modules/nyc/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/package.json",
+      "bundled": [
+        "goof@0.0.3",
+        "nyc@6.6.1",
+        "spawn-wrap@1.2.3"
+      ],
+      "parentDepType": "prod",
+      "fixedIn": [
+      ]
+    }
+  ],
+  "dependencyCount": 428,
+  "org": "deebugger",
+  "licensesPolicy": null,
+  "summary": "33 vulnerable dependency paths",
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 18,
+  "packageManager": "npm"
+}

--- a/test/fixtures/test-report-with-no-remediation-with-multiple-fixed-in.json
+++ b/test/fixtures/test-report-with-no-remediation-with-multiple-fixed-in.json
@@ -1,0 +1,82 @@
+{
+  "ok": false,
+  "vulnerabilities": [
+    {
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "credit": [
+        "kamael"
+      ],
+      "moduleName": "brace-expansion",
+      "packageName": "brace-expansion",
+      "language": "js",
+      "packageManager": "npm",
+      "description": "## Overview\n[`brace-expansion`](https://www.npmjs.com/package/brace-expansion) is a package that performs brace expansion as known from sh/bash.\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.\nRunning:\n```js\nconst expand = require('brace-expansion');\nexpand('{,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,\\n}')\n```\nWill hang for long periods of time.\n\n## Details\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack.  Many Regular Expression implementations may reach edge cases that causes them to work very slowly (exponentially related to input size), allowing an attacker to exploit this and can cause the program to enter these extreme situations by using a Regex string and cause the service to hang for a large periods of time.\n\nYou can read more about `Regular Expression Denial of Service (ReDoS)` on our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\n\n",
+      "identifiers": {
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "NSP": 338,
+        "ALTERNATIVE": [
+          "SNYK-JS-BRACEEXPANSION-10483"
+        ]
+      },
+      "semver": {
+        "unaffected": ">=1.1.7",
+        "vulnerable": "<1.1.7"
+      },
+      "patches": [],
+      "severity": "medium",
+      "CVSSv3": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "disclosureTime": "2017-03-01T22:00:00.000Z",
+      "publicationTime": "2017-04-26T09:19:21.663Z",
+      "modificationTime": "2017-04-26T09:19:21.663Z",
+      "creationTime": "2017-04-26T09:19:21.663Z",
+      "id": "npm:brace-expansion:20170302",
+      "alternativeIds": [
+        "SNYK-JS-BRACEEXPANSION-10483"
+      ],
+      "from": [
+        "goof@0.0.3",
+        "tap@5.8.0",
+        "nyc@6.6.1",
+        "glob@7.0.3",
+        "minimatch@3.0.0",
+        "brace-expansion@1.1.4"
+      ],
+      "upgradePath": [
+        false,
+        "tap@5.8.0",
+        "nyc@6.6.1",
+        "glob@7.0.3",
+        "minimatch@3.0.0",
+        "brace-expansion@1.1.7"
+      ],
+      "version": "1.1.4",
+      "name": "brace-expansion",
+      "isUpgradable": true,
+      "isPatchable": false,
+      "__filename": "/Users/dror/work/repos/snyk/goof/node_modules/nyc/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/package.json",
+      "bundled": [
+        "goof@0.0.3",
+        "nyc@6.6.1",
+        "spawn-wrap@1.2.3"
+      ],
+      "parentDepType": "prod",
+      "fixedIn": [
+        "2.9.10",
+        "4.5.6"
+      ]
+    }
+  ],
+  "dependencyCount": 428,
+  "org": "deebugger",
+  "licensesPolicy": null,
+  "summary": "33 vulnerable dependency paths",
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 18,
+  "packageManager": "npm"
+}

--- a/test/fixtures/test-report-with-no-remediation-with-one-fixed-in.json
+++ b/test/fixtures/test-report-with-no-remediation-with-one-fixed-in.json
@@ -1,0 +1,81 @@
+{
+  "ok": false,
+  "vulnerabilities": [
+    {
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "credit": [
+        "kamael"
+      ],
+      "moduleName": "brace-expansion",
+      "packageName": "brace-expansion",
+      "language": "js",
+      "packageManager": "npm",
+      "description": "## Overview\n[`brace-expansion`](https://www.npmjs.com/package/brace-expansion) is a package that performs brace expansion as known from sh/bash.\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.\nRunning:\n```js\nconst expand = require('brace-expansion');\nexpand('{,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,\\n}')\n```\nWill hang for long periods of time.\n\n## Details\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack.  Many Regular Expression implementations may reach edge cases that causes them to work very slowly (exponentially related to input size), allowing an attacker to exploit this and can cause the program to enter these extreme situations by using a Regex string and cause the service to hang for a large periods of time.\n\nYou can read more about `Regular Expression Denial of Service (ReDoS)` on our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\n\n",
+      "identifiers": {
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "NSP": 338,
+        "ALTERNATIVE": [
+          "SNYK-JS-BRACEEXPANSION-10483"
+        ]
+      },
+      "semver": {
+        "unaffected": ">=1.1.7",
+        "vulnerable": "<1.1.7"
+      },
+      "patches": [],
+      "severity": "medium",
+      "CVSSv3": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "disclosureTime": "2017-03-01T22:00:00.000Z",
+      "publicationTime": "2017-04-26T09:19:21.663Z",
+      "modificationTime": "2017-04-26T09:19:21.663Z",
+      "creationTime": "2017-04-26T09:19:21.663Z",
+      "id": "npm:brace-expansion:20170302",
+      "alternativeIds": [
+        "SNYK-JS-BRACEEXPANSION-10483"
+      ],
+      "from": [
+        "goof@0.0.3",
+        "tap@5.8.0",
+        "nyc@6.6.1",
+        "glob@7.0.3",
+        "minimatch@3.0.0",
+        "brace-expansion@1.1.4"
+      ],
+      "upgradePath": [
+        false,
+        "tap@5.8.0",
+        "nyc@6.6.1",
+        "glob@7.0.3",
+        "minimatch@3.0.0",
+        "brace-expansion@1.1.7"
+      ],
+      "version": "1.1.4",
+      "name": "brace-expansion",
+      "isUpgradable": true,
+      "isPatchable": false,
+      "__filename": "/Users/dror/work/repos/snyk/goof/node_modules/nyc/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/package.json",
+      "bundled": [
+        "goof@0.0.3",
+        "nyc@6.6.1",
+        "spawn-wrap@1.2.3"
+      ],
+      "parentDepType": "prod",
+      "fixedIn": [
+        "2.9.10"
+      ]
+    }
+  ],
+  "dependencyCount": 428,
+  "org": "deebugger",
+  "licensesPolicy": null,
+  "summary": "33 vulnerable dependency paths",
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 18,
+  "packageManager": "npm"
+}

--- a/test/snyk-to-html.test.ts
+++ b/test/snyk-to-html.test.ts
@@ -1,39 +1,123 @@
+import path = require('path');
 import {test} from 'tap';
 import { SnykToHtml } from '../src/lib/snyk-to-html';
-import path = require('path');
 
-test('all-around test', function (t) {
-  t.plan(3);
+const summaryOnly = true;
+const noSummary = false;
+
+test('all-around test', (t) => {
+  t.plan(5);
   SnykToHtml.run(
     path.join(__dirname, 'fixtures', 'test-report.json'),
     path.join(__dirname, '..', 'template', 'test-report.hbs'),
-    function (report) {
-      t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)<\/h2>');
-      t.contains(report, '<h2 class="card__title">Cross-site Scripting (XSS)</h2>');
-      t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>');
+      noSummary,
+     (report) => {
+      t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)<\/h2>', 'should contain Regular Expression Denial of Service (ReDoS) vulnerability');
+      t.contains(report, '<h2 class="card__title">Cross-site Scripting (XSS)</h2>', 'should contain Cross-site Scripting (XSS) vulnerability');
+      t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>', 'should contain Regular Expression Denial of Service (DoS) vulnerability');
+      t.contains(report, '<h2 id="overview">Overview</h2>', 'should contain overview of the vulnerability');
+      t.contains(report, '<h2 id="details">Details</h2>', 'should contain description of the vulnerability');
     });
 });
 
-test('multi-report test', function (t) {
-  t.plan(5);
+test('multi-report test', (t) => {
+  t.plan(7);
   SnykToHtml.run(
     path.join(__dirname, 'fixtures', 'multi-test-report.json'),
     path.join(__dirname, '..', 'template', 'test-report.hbs'),
-    function (report) {
-      t.contains(report, '<div class="meta-count"><span>139 vulnerable dependency paths</span></div>');
-      t.contains(report, '<h2 class="card__title">Access Restriction Bypass</h2>');
-      t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)<\/h2>');
-      t.contains(report, '<h2 class="card__title">Cross-site Scripting (XSS)</h2>');
-      t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>');
+      noSummary,
+     (report) => {
+      t.contains(report, '<div class="meta-count"><span>139 vulnerable dependency paths</span></div>', 'should contain number of vulnerable dependency paths');
+      t.contains(report, '<h2 class="card__title">Access Restriction Bypass</h2>', 'should contain Access Restriction Bypass vulnerability');
+      t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)<\/h2>', 'should contain Regular Expression Denial of Service (ReDoS) vulnerability');
+      t.contains(report, '<h2 class="card__title">Cross-site Scripting (XSS)</h2>', 'should contain Cross-site Scripting (XSS) vulnerability');
+      t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>', 'should contain Regular Expression Denial of Service (DoS) vulnerability');
+      t.contains(report, '<h2 id="overview">Overview</h2>', 'should contain overview of the vulnerability');
+      t.contains(report, '<h2 id="details">Details</h2>', 'should contain description of the vulnerability');
     });
 });
 
-test('empty values test (description and info)', function (t) {
+test('multi-report test with summary only', (t) => {
+  t.plan(7);
+  SnykToHtml.run(
+      path.join(__dirname, 'fixtures', 'multi-test-report.json'),
+      path.join(__dirname, '..', 'template', 'test-report.hbs'),
+      summaryOnly,
+      (report) => {
+        t.contains(report, '<div class="meta-count"><span>139 vulnerable dependency paths</span></div>', 'should contain number of vulnerable dependency paths');
+        t.contains(report, '<h2 class="card__title">Access Restriction Bypass</h2>', 'should contain Access Restriction Bypass vulnerability');
+        t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)<\/h2>', 'should contain Regular Expression Denial of Service (ReDoS) vulnerability');
+        t.contains(report, '<h2 class="card__title">Cross-site Scripting (XSS)</h2>', 'should contain Cross-site Scripting (XSS) vulnerability');
+        t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>', 'should contain Regular Expression Denial of Service (DoS) vulnerability');
+        t.doesNotHave(report, '<h2 id="overview">Overview</h2>', 'does not contain overview of the vulnerability');
+        t.doesNotHave(report, '<h2 id="details">Details</h2>', 'does not contain details of the vulnerability');
+      });
+});
+
+test('all-around test with summary only', (t) => {
+  t.plan(5);
+  SnykToHtml.run(
+      path.join(__dirname, 'fixtures', 'test-report.json'),
+      path.join(__dirname, '..', 'template', 'test-report.hbs'),
+      summaryOnly,
+      (report) => {
+        t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)<\/h2>', 'should contain Regular Expression Denial of Service (ReDoS) vulnerability');
+        t.contains(report, '<h2 class="card__title">Cross-site Scripting (XSS)</h2>', 'should contain Cross-site Scripting (XSS) vulnerability');
+        t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>', 'should contain Regular Expression Denial of Service (DoS) vulnerability');
+        t.doesNotHave(report, '<h2 id="overview">Overview</h2>', 'does not contain overview of the vulnerability');
+        t.doesNotHave(report, '<h2 id="details">Details</h2>', 'does not contain details of the vulnerability');
+      });
+});
+
+test('all-around test with summary only with no remediation but having one fixedIn', (t) => {
+  t.plan(4);
+  SnykToHtml.run(
+      path.join(__dirname, 'fixtures', 'test-report-with-no-remediation-with-one-fixed-in.json'),
+      path.join(__dirname, '..', 'template', 'test-report.hbs'),
+      summaryOnly,
+      (report) => {
+        t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)<\/h2>', 'should contain Regular Expression Denial of Service (ReDoS) vulnerability');
+        t.contains(report, 'Fixed in: 2.9.10', 'should say: Fixed in: 2.9.10');
+        t.doesNotHave(report, '<h2 id="overview">Overview</h2>', 'does not contain overview of the vulnerability');
+        t.doesNotHave(report, '<h2 id="details">Details</h2>', 'does not contain details of the vulnerability');
+      });
+});
+
+test('all-around test with summary only with no remediation but having multiple fixedIn', (t) => {
+  t.plan(4);
+  SnykToHtml.run(
+      path.join(__dirname, 'fixtures', 'test-report-with-no-remediation-with-multiple-fixed-in.json'),
+      path.join(__dirname, '..', 'template', 'test-report.hbs'),
+      summaryOnly,
+      (report) => {
+        t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)<\/h2>', 'should contain Regular Expression Denial of Service (ReDoS) vulnerability');
+        t.contains(report, 'Fixed in: 2.9.10, 4.5.6', 'should say: Fixed in: 2.9.10, 4.5.6');
+        t.doesNotHave(report, '<h2 id="overview">Overview</h2>', 'does not contain overview of the vulnerability');
+        t.doesNotHave(report, '<h2 id="details">Details</h2>', 'does not contain details of the vulnerability');
+      });
+});
+
+test('all-around test with summary only with no remediation and no fixedIns', (t) => {
+  t.plan(4);
+  SnykToHtml.run(
+      path.join(__dirname, 'fixtures', 'test-report-with-no-remediation-and-no-fixed-in.json'),
+      path.join(__dirname, '..', 'template', 'test-report.hbs'),
+      summaryOnly,
+      (report) => {
+        t.contains(report, '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)<\/h2>', 'should contain Regular Expression Denial of Service (ReDoS) vulnerability');
+        t.contains(report, 'There is no remediation at the moment', 'should say There is no remediation at the moment');
+        t.doesNotHave(report, '<h2 id="overview">Overview</h2>', 'does not contain overview of the vulnerability');
+        t.doesNotHave(report, '<h2 id="details">Details</h2>', 'does not contain details of the vulnerability');
+      });
+});
+
+test('empty values test (description and info)', (t) => {
   t.plan(1);
   SnykToHtml.run(
-    path.join(__dirname, 'fixtures', 'test-report-empty-descr.json'),
-    path.join(__dirname, '..', 'template', 'test-report.hbs'),
-    function (report) {
-      t.contains(report, '<p>No description available.</p>');
-    });
+      path.join(__dirname, 'fixtures', 'test-report-empty-descr.json'),
+      path.join(__dirname, '..', 'template', 'test-report.hbs'),
+      noSummary,
+      (report) => {
+        t.contains(report, '<p>No description available.</p>', 'should contain "No description available"');
+      });
 });


### PR DESCRIPTION
implementation for #22 

 ## Normal report, without specifying the `-s` parameter
```cat test/fixtures/test-report.json | node dist/index.js  -o before.html```


<img width="1396" alt="detailed-report" src="https://user-images.githubusercontent.com/442744/72884227-76314b80-3d0e-11ea-93f7-53f7210e24db.png">

 ## Summary report, providing `-s` parameter
```cat test/fixtures/test-report.json | node dist/index.js  -o before.html```


<img width="1387" alt="with-summary-only" src="https://user-images.githubusercontent.com/442744/72884310-97923780-3d0e-11ea-8574-fcb817db9a1a.png">

## More examples with summary only

### When no remediation present in `metadata.description`, we'll look in `vuln.fixedIn`

#### One `fixedIn` value
<img width="858" alt="on-fixed-in" src="https://user-images.githubusercontent.com/442744/73015316-758ad900-3e24-11ea-9a6b-2e8a6a9b0cff.png">

#### Multiple `fixedIn` value
<img width="877" alt="multiple-fixed-ins" src="https://user-images.githubusercontent.com/442744/73015322-77ed3300-3e24-11ea-86fa-7464e833e028.png">

### When no value for`vuln.fixedIn` present, fallback to a default message
<img width="912" alt="fallback-message" src="https://user-images.githubusercontent.com/442744/73015332-7c195080-3e24-11ea-95a0-da8a9470b4af.png">
