### PR TITLE
feat: sort report in descending order of severity and name

### DIFF
--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import * as debugModule from 'debug';
 import fs = require('fs');
 import Handlebars = require('handlebars');
+import * as _ from 'lodash';
 import marked = require('marked');
 import moment = require('moment');
 import path = require('path');
@@ -119,7 +120,12 @@ async function registerPeerPartial(templatePath: string, name: string): Promise<
 
 async function generateTemplate(data: any, template: string, summary: boolean): Promise<string> {
   const vulnMetadata = groupVulns(data.vulnerabilities);
-  data.vulnerabilities = vulnMetadata.vulnerabilities;
+  const sortedVulns = _.orderBy(
+    vulnMetadata.vulnerabilities,
+    ['metadata.severityValue', 'metadata.name'],
+    ['desc', 'desc'],
+  );
+  data.vulnerabilities = sortedVulns;
   data.uniqueCount = vulnMetadata.vulnerabilitiesUniqueCount;
   data.summary = vulnMetadata.vulnerabilitiesPathsCount + ' vulnerable dependency paths';
   data.showSummaryOnly = summary;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,9 @@
         "pretty": true,
         "target": "es2015",
         "lib": [
-          "es2015"
+          "es6",
+          "dom",
+          "es2017.object"
         ],
         "module": "commonjs",
         "allowJs": false,


### PR DESCRIPTION
In response to GitHub Issue 63
Orders vulnerabilities in descending order of severity, and in descending alphabetical order of names.

![image](https://user-images.githubusercontent.com/62237867/78146883-aa219f00-742a-11ea-8d9a-3e56197ef925.png)
