### PR TITLE
Update vulnerable dependency and drop Node.js 8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,16 @@
     "chalk": "^2.4.2",
     "commander": "^4.1.1",
     "debug": "^4.1.1",
-    "handlebars": "^4.7.3",
-    "marked": "^1.1.1",
+    "handlebars": "^4.7.7",
+    "marked": "^2.0.7",
     "moment": "^2.24.0",
     "source-map-support": "^0.5.16"
   },
   "bin": {
     "snyk-to-html": "dist/index.js"
+  },
+  "engines": {
+    "node": ">=10"
   },
   "snyk": true,
   "devDependencies": {


### PR DESCRIPTION
Updating dependencies to fix vulnerabilities

BREAKING CHANGE: Dropping Node 8 support
Snyk CLI dropped Node 8 support in Feb 2021 https://updates.snyk.io/ending-snyk-cli-support-for-node-js-8-x-183304