### PR TITLE
chore: set AWS env vars in semantic-release step

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -70,5 +70,8 @@ jobs:
       - run: semantic-release
         env:
           PUBLIC_S3_BUCKET: ${{secrets.PUBLIC_S3_BUCKET}}
+          AWS_DEFAULT_REGION: ${{secrets.AWS_DEFAULT_REGION}}
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Add AWS env vars to the semantic-release step in GitHub actions.