### PR TITLE
Use node 14 for binary releases

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,7 @@
     {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg && pkg . -t node8-alpine-x64,node8-linux-x64,node8-macos-x64,node8-win-x64"
+      "cmd": "npm i -g pkg && pkg . -t node14-alpine-x64,node14-linux-x64,node14-macos-x64,node14-win-x64"
     },
     {
       "//": "shasum all binaries",


### PR DESCRIPTION
Use node 14 for binary releases for compatibility with marked@2
