### PR TITLE
chore: update cloud config to group iac ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @snyk/boost
 * @snyk/hammer
-template/iac/* @snyk/cloudconfig
+template/iac/* @snyk/group-infrastructure-as-code


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commits are squashed and tidy and are suitable to become release notes

### What this does

Updates code ownership as cloud config team grew to a group and changes its name to a wider scope.
