### PR TITLE
fix: Missing Remediation in IaC Reports

### DIFF
--- a/src/lib/vuln.ts
+++ b/src/lib/vuln.ts
@@ -61,7 +61,7 @@ export function addIssueDataToPatch(remediation, vulnerabilities) {
 }
 
 export const IacProjectType = {
-  k8config: 'Kubernetes',
+  k8sconfig: 'Kubernetes',
   terraformconfig: 'Terraform',
   cloudformationconfig: 'CloudFormation',
   armconfig: 'ARM',

--- a/template/iac/test-report.vuln-card.hbs
+++ b/template/iac/test-report.vuln-card.hbs
@@ -32,11 +32,7 @@
             <p>{{impact}}</p>
 
             <h2>Remediation</h2>
-            <ul>
-                {{#each remediation}}
-                    <li>{{@key}}: {{this}}</li>
-                {{/each}}
-            </ul>
+            <p>{{resolve}}</p>
             
 
             <h2>References</h2>


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commits are squashed and tidy and are suitable to become release notes

### What this does

This PR fixed 2 issues:
1. Missing remediation in some reports
2. Wrong value for the K8 project type

### More information

[Slack Thread](https://snyk.slack.com/archives/CRV0PMFDH/p1638295682103400)
