### PR TITLE
chore: update marked to 4.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "commander": "^4.1.1",
     "debug": "^4.1.1",
     "handlebars": "^4.7.7",
-    "marked": "^2.0.7",
+    "marked": "^4.0.12",
     "moment": "^2.24.0",
     "source-map-support": "^0.5.16"
   },

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -273,7 +273,7 @@ async function processIacData(data: any, template: string, summary: boolean): Pr
     };
   });
   const totalIssues = projectsArrays.reduce((acc, item) => acc + item.infrastructureAsCodeIssues.length || 0, 0);
-  
+
   const processedData = {
     projects: projectsArrays,
     showSummaryOnly: summary,
@@ -300,7 +300,7 @@ async function readInputFromStdin(): Promise<string> {
 
 // handlebar helpers
 const hh = {
-  markdown: marked,
+  markdown: marked.parse,
   moment: (date, format) => moment.utc(date).format(format),
   count: data => data && data.length,
   dump: (data, spacer) => JSON.stringify(data, null, spacer || null),
@@ -335,16 +335,16 @@ const hh = {
     // check remediation in the description
     const index = description.indexOf('## Remediation');
     if (index > -1) {
-      return marked(description.substring(index));
+      return marked.parse(description.substring(index));
     }
     // if no remediation in description, try to check in `fixedIn` attribute
     if (Array.isArray(fixedIn) && fixedIn.length) {
       const fixedInJoined = fixedIn.join(', ');
-      return marked(`## Remediation\n Fixed in: ${fixedInJoined}`);
+      return marked.parse(`## Remediation\n Fixed in: ${fixedInJoined}`);
     }
 
     // otherwise, fallback to default message, i.e. No remediation at the moment
-    return marked(defaultRemediationText);
+    return marked.parse(defaultRemediationText);
   },
   severityLabel: (severity: string) => {
     return severity[0].toUpperCase();

--- a/tap-snapshots/test-snyk-to-html.test.ts-TAP.test.js
+++ b/tap-snapshots/test-snyk-to-html.test.ts-TAP.test.js
@@ -2602,11 +2602,11 @@ exports[`test/snyk-to-html.test.ts TAP template output displays vulns in descend
         </code></pre>
         </li>
         <li><p>Override getContentType in XStreamHandler</p>
-        <pre><code class="language-java">public class MyXStreamHandler extends XStreamHandler { 
+        <pre><code class="language-java"> public class MyXStreamHandler extends XStreamHandler { 
         public String getContentType() {
           return &quot;not-existing-content-type-@;/&amp;%$#@&quot;;
         }
-        }
+         }
         </code></pre>
         </li>
         <li><p>Register the handler by overriding the one provided by the framework in your struts.xml</p>


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commits are squashed and tidy and are suitable to become release notes

### What this does

to fix and supersede #114 

### Notes for the reviewer

It appears that the test fixture markdown has some spaces that had previously been ignored by marked, so the html output is a bit different. I updated the tap snapshot using the TAP_SNAPSHOT=1 method to adjust the expected output from the tests.

### More information

none

### Screenshots

n/a
