### PR TITLE
remove logging instruction

### DIFF
--- a/template/code/test-report.hbs
+++ b/template/code/test-report.hbs
@@ -16,7 +16,6 @@
   {{> metatable-css }}
 </head>
 
-{{log this}}
 <body class="section-projects">
   <main class="layout-stacked">
     {{> header }}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Commits are squashed and tidy and are suitable to become release notes

### What this does

Removes a log statement in the code template which caused json trees to be printed on standard out

