### PR TITLE
fix: decode whitespace path for ticket 23287

### DIFF
--- a/src/lib/codeutil.ts
+++ b/src/lib/codeutil.ts
@@ -81,8 +81,10 @@ async function processCodeLine(filePath, region) {
 };
 
 async function readCodeSnippet(codeInfomation){
+  const decodedpath = decodeURI(codeInfomation.physicalLocation.artifactLocation.uri);
   const filePath = path.resolve(
-    codeInfomation.physicalLocation.artifactLocation.uri,
+    //codeInfomation.physicalLocation.artifactLocation.uri,
+    decodedpath,
   );
   const codeRegion = codeInfomation.physicalLocation.region;
   const result = await processCodeLine(filePath, codeRegion);


### PR DESCRIPTION
### What this does

This PR fixes a bug according to ZenDesk ticket [#23287](https://snyk.zendesk.com/agent/tickets/23287).

There was a problem showing the data flow analysis when there were whitespaces in the path to the file.

### Screenshots

Before:
<img width="1107" alt="image" src="https://user-images.githubusercontent.com/97087926/166892667-c79ea436-2b62-4f8c-b026-39eee0d1736c.png">

After:
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/97087926/166892706-9111af02-1ae5-4a8e-966d-6f719e10a198.png">


