### PR TITLE
fix: snyk-to-html for IaC [CFG-1985]

### DIFF
--- a/tap-snapshots/test-snyk-to-html.test.ts-TAP.test.js
+++ b/tap-snapshots/test-snyk-to-html.test.ts-TAP.test.js
@@ -474,7 +474,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                 </div>
     
                 <div class="meta-counts">
-                  <div class="meta-count"><span>28</span> <span>total issues</span></div>
+                  <div class="meta-count"><span>30</span> <span>total issues</span></div>
                 </div><!-- .meta-counts -->
             </div><!-- .layout-container--short -->
           </header><!-- .project__header -->
@@ -667,6 +667,44 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
               </div><!-- .card -->
               <div class="card card--vuln  disclosure--not-new severity--medium" data-snyk-test="medium">
+                  <h2 class="card__title">Missing a description and an owner from tag, or owner tag does not comply with email requirements</h2>
+                  <div class="card__section">
+              
+                      <div class="label label--medium">
+                          <span class="label__text">medium severity</span>
+                      </div>
+              
+                      <hr/>
+              
+                      <ul class="card__meta">
+                          <li class="card__meta__item">
+                              Public ID: CUSTOM-RULE-4 
+                          </li>
+              
+                          <li class="card__meta__item">Introduced through:
+                                  input
+                                   <span class="list-paths__item__arrow">›</span> 
+                                  resource
+                                   <span class="list-paths__item__arrow">›</span> 
+                                  aws_redshift_cluster[denied2]
+                                   <span class="list-paths__item__arrow">›</span> 
+                                  tags
+                                  
+                          </li>
+              
+                          <li class="card__meta__item">
+                              Line number: 16
+                          </li>
+                      </ul>
+              
+                      
+                  </div><!-- .card__section -->
+              
+                  <div class="cta card__cta">
+                  </div>
+              
+              </div><!-- .card -->
+              <div class="card card--vuln  disclosure--not-new severity--medium" data-snyk-test="medium">
                   <h2 class="card__title">Storage Account does not enforce latest TLS</h2>
                   <div class="card__section">
               
@@ -853,6 +891,41 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                   <div class="cta card__cta">
                       <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-162">More about this issue</a></p>
+                  </div>
+              
+              </div><!-- .card -->
+              <div class="card card--vuln  disclosure--not-new severity--low" data-snyk-test="low">
+                  <h2 class="card__title">Redshift cluster logging disabled</h2>
+                  <div class="card__section">
+              
+                      <div class="label label--low">
+                          <span class="label__text">low severity</span>
+                      </div>
+              
+                      <hr/>
+              
+                      <ul class="card__meta">
+                          <li class="card__meta__item">
+                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-136">SNYK-CC-TF-136</a> 
+                          </li>
+              
+                          <li class="card__meta__item">Introduced through:
+                                  resource
+                                   <span class="list-paths__item__arrow">›</span> 
+                                  aws_redshift_cluster[denied2]
+                                   <span class="list-paths__item__arrow">›</span> 
+                                  logging
+                                  
+                          </li>
+              
+                      </ul>
+              
+                      <hr/>
+              
+                  </div><!-- .card__section -->
+              
+                  <div class="cta card__cta">
+                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-136">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->

--- a/template/iac/test-report.vuln-card.hbs
+++ b/template/iac/test-report.vuln-card.hbs
@@ -10,7 +10,7 @@
 
         <ul class="card__meta">
             <li class="card__meta__item">
-                Public ID: <a href="{{documentation}}">{{publicId}}</a> 
+                Public ID: {{#if documentation}}<a href="{{documentation}}">{{publicId}}</a>{{else}}{{publicId}}{{/if}} 
             </li>
 
             <li class="card__meta__item">Introduced through:
@@ -20,21 +20,35 @@
                 {{/each}}
             </li>
 
+            {{#ifCond lineNumber '>' -1}}
             <li class="card__meta__item">
                 Line number: {{lineNumber}}
             </li>
+            {{/ifCond}}
         </ul>
 
+        {{#if impact}}
         <hr/>
+        {{else if resolve}}
+        <hr/>
+        {{else}}
+        {{#ifCond (count references) '>' 0}}
+        <hr/>
+        {{/ifCond}}
+        {{/if}}
 
         {{#unless @root.showSummaryOnly}}
+            {{#if impact}}
             <h2>Impact</h2>
             <p>{{impact}}</p>
+            {{/if}}
 
+            {{#if resolve}}
             <h2>Remediation</h2>
             <p>{{resolve}}</p>
-            
+            {{/if}}
 
+            {{#ifCond (count references.length) '>' 0}}
             <h2>References</h2>
             <ul>
                 {{#each references}}
@@ -45,13 +59,24 @@
                     {{/startsWith}}
                 {{/each}}
             </ul>
+            {{/ifCond}}
 
+            {{#if impact}}
             <hr/>
+            {{else if resolve}}
+            <hr/>
+            {{else}}
+            {{#ifCond (count references) '>' 0}}
+            <hr/>
+            {{/ifCond}}
+            {{/if}}
         {{/unless}}
     </div><!-- .card__section -->
 
     <div class="cta card__cta">
+        {{#if documentation}}
         <p><a href="{{documentation}}">More about this issue</a></p>
+        {{/if}}
     </div>
 
 </div><!-- .card -->

--- a/test/fixtures/iac-test-report.json
+++ b/test/fixtures/iac-test-report.json
@@ -78,6 +78,62 @@
     "infrastructureAsCodeIssues": [
       {
         "severity": "low",
+        "resolve": "Set `logging.enable` attribute to `true`",
+        "id": "SNYK-CC-TF-136",
+        "impact": "Audit records may not be available during investigation",
+        "msg": "resource.aws_redshift_cluster[denied2].logging",
+        "remediation": {
+          "cloudformation": "Set `Properties.LoggingProperties` attribute",
+          "terraform": "Set `logging.enable` attribute to `true`"
+        },
+        "subType": "Redshift",
+        "issue": "Amazon Redshift cluster logging is not enabled",
+        "publicId": "SNYK-CC-TF-136",
+        "title": "Redshift cluster logging disabled",
+        "references": [
+          "https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html"
+        ],
+        "isIgnored": false,
+        "iacDescription": {
+          "issue": "Amazon Redshift cluster logging is not enabled",
+          "impact": "Audit records may not be available during investigation",
+          "resolve": "Set `logging.enable` attribute to `true`"
+        },
+        "lineNumber": -1,
+        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-136",
+        "isGeneratedByCustomRule": false,
+        "path": [
+          "resource",
+          "aws_redshift_cluster[denied2]",
+          "logging"
+        ]
+      },
+      {
+        "severity": "medium",
+        "impact": "",
+        "msg": "input.resource.aws_redshift_cluster[denied2].tags",
+        "remediation": "",
+        "issue": "",
+        "publicId": "CUSTOM-RULE-4",
+        "title": "Missing a description and an owner from tag, or owner tag does not comply with email requirements",
+        "references": [],
+        "id": "CUSTOM-RULE-4",
+        "isIgnored": false,
+        "iacDescription": {
+          "issue": "",
+          "impact": ""
+        },
+        "lineNumber": 16,
+        "isGeneratedByCustomRule": true,
+        "path": [
+          "input",
+          "resource",
+          "aws_redshift_cluster[denied2]",
+          "tags"
+        ]
+      },
+      {
+        "severity": "low",
         "resolve": "Set `properties.clientCertEnabled` attribute to `true`",
         "impact": "Clients without authorized certificate may be allowed to connect to the application",
         "msg": "resources[3].properties.clientCertEnabled",


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commits are squashed and tidy and are suitable to become release notes

### What this does

This PR fixes some issues in IaC such as:
- when the line number is `-1` we don't want to show it
- when the rule doesn't have a documentation link we don't make the id a link and don't include an external link at the bottom of the card
- when the rule doesn't have an issue, impact, or remediation we don't show them (this is for custom rules only)

### Notes for the reviewer

To test, run `node ./dist/index.js -i test/fixtures/iac-test-report.json -o results.html`

### More information

- [Link to issue](https://snyksec.atlassian.net/browse/CFG-1985)

### Screenshots
![Screenshot 2022-06-17 at 17 07 58](https://user-images.githubusercontent.com/81559517/174335888-72ff03ff-f6a6-4342-a533-94b54a1fe7fc.png)
![Screenshot 2022-06-17 at 17 08 00](https://user-images.githubusercontent.com/81559517/174335892-c4921f69-a702-486d-bcfb-90fbded0a353.png)
![Screenshot 2022-06-17 at 17 08 07](https://user-images.githubusercontent.com/81559517/174335895-babbba15-df43-4029-8520-38eae3ad5ab5.png)

