### PR TITLE
docs: update documentation for -t argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ node ./dist/index.js
 
 | Short | Long                       | Description                                                                                                      |
 | ----- | -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `-t`  | `--template`               | Template location for generating the html. Defaults to template/test-report.hbs                                  |
+| `-t`  | `--template`               | Template location for generating the html. Defaults to template/test-report.hbs<br/><br/>If using a custom template, snyk-to-html expects the template to be installed in the package's templates folder, regardless of any path specified in the `-t` argument. By default, this folder resides at `{npm_prefix}/lib/node_modules/snyk-to-html/template` |
 | `-i`  | `--input`                  | Input path from where to read the json. Defaults to stdin                                                        |
 | `-o`  | `--output`                 | Output of the resulting HTML. Example: -o snyk.html. Defaults to stdout                                          |
 | `-s`  | `--summary`                | Generates an HTML with only the summary, instead of the details report. Defaults to details vulnerability report |


### PR DESCRIPTION
- [ N/A ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ x ] Commits are squashed and tidy and are suitable to become release notes

### What this does

Updates documentation for the `-t` argument to clarify that custom templates need to be installed in the packages `template` directory.

### Notes for the reviewer

Failing to do this results in an error due to includes that cannot be found.

### More information

N/A

### Screenshots
<img width="1437" alt="Screenshot 2022-12-02 at 12 34 05 PM" src="https://user-images.githubusercontent.com/59919895/205362474-b74134ca-8277-4cc7-9404-3df799222011.png">

