### PR TITLE
docs: add examples for four products on using this

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,20 @@ Snyk JSON to HTML Mapper mapper works with the different Snyk Products.  Change 
 
 1. Directly streaming the results to snyk-to-html:
 
-   For Snyk Open Source
+   **For Snyk Open Source
 
    Run the following line to create a file called `results-opensource.html`:
 
    `snyk test --json | snyk-to-html -o results-opensource.html`
 
-   For Snyk Code
+   **For Snyk Code
 
    Run the following line to create a file called `results-code.html`:
 
    `snyk code test --json | snyk-to-html -o results-code.html`
 
 
-   For Snyk Infrastructure as Code (IaC)
+   **For Snyk Infrastructure as Code (IaC)
    Navigate to the subfolder with the related files.
 
    Run the following line to create a file called `results-iac.html`:
@@ -62,7 +62,7 @@ Snyk JSON to HTML Mapper mapper works with the different Snyk Products.  Change 
    `snyk iac test --json | snyk-to-html -o results-iac.html`
 
 
-   For Snyk Container
+   **For Snyk Container
 
    Run the following line to create a file called `results-container.html`:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ When in doubt, use `snyk-to-html --help` or `snyk-to-html -h`.
 
 ## Generate the HTML report
 
-Snyk JSON to HTML Mapper mapper works with the different Snyk Products.  Change directory to your package's root folder, then use  one of the  ways below to generate the HTML report, using the appropriate product's command
+Snyk JSON to HTML Mapper mapper works with the different Snyk Products.  Change the directory to your package's root folder, then use  one of the  ways below to generate the HTML report, using the appropriate product's command
 
 1. Directly streaming the results to snyk-to-html:
 

--- a/README.md
+++ b/README.md
@@ -43,32 +43,32 @@ Snyk JSON to HTML Mapper mapper works with the different Snyk Products.  Change 
 
    **For Snyk Open Source**
 
-   Run the following line to create a file called `results-opensource.html`:
+      Run the following line to create a file called `results-opensource.html`:
 
-   `snyk test --json | snyk-to-html -o results-opensource.html`
+      `snyk test --json | snyk-to-html -o results-opensource.html`
 
    **For Snyk Code**
 
-   Run the following line to create a file called `results-code.html`:
+      Run the following line to create a file called `results-code.html`:
 
-   `snyk code test --json | snyk-to-html -o results-code.html`
+      `snyk code test --json | snyk-to-html -o results-code.html`
 
 
    **For Snyk Infrastructure as Code (IaC)**
-   Navigate to the subfolder with the related files.
+      Navigate to the subfolder with the related files.
 
-   Run the following line to create a file called `results-iac.html`:
+      Run the following line to create a file called `results-iac.html`:
 
-   `snyk iac test --json | snyk-to-html -o results-iac.html`
+      `snyk iac test --json | snyk-to-html -o results-iac.html`
 
 
    **For Snyk Container**
 
-   Run the following line to create a file called `results-container.html`:
+    Run the following line to create a file called `results-container.html`:
 
-   `snyk container test [image] --json | snyk-to-html -o results-container.html`
+      `snyk container test [image] --json | snyk-to-html -o results-container.html`
 
-   The following methods/examples will utilize snyk test, however they will also work with the other product commands , as above.
+      The following methods/examples will utilize snyk test, however they will also work with the other product commands , as above.
 
 2. Using a temporary file:
 

--- a/README.md
+++ b/README.md
@@ -41,20 +41,20 @@ Snyk JSON to HTML Mapper mapper works with the different Snyk Products.  Change 
 
 1. Directly streaming the results to snyk-to-html:
 
-   **For Snyk Open Source
+   **For Snyk Open Source**
 
    Run the following line to create a file called `results-opensource.html`:
 
    `snyk test --json | snyk-to-html -o results-opensource.html`
 
-   **For Snyk Code
+   **For Snyk Code**
 
    Run the following line to create a file called `results-code.html`:
 
    `snyk code test --json | snyk-to-html -o results-code.html`
 
 
-   **For Snyk Infrastructure as Code (IaC)
+   **For Snyk Infrastructure as Code (IaC)**
    Navigate to the subfolder with the related files.
 
    Run the following line to create a file called `results-iac.html`:
@@ -62,7 +62,7 @@ Snyk JSON to HTML Mapper mapper works with the different Snyk Products.  Change 
    `snyk iac test --json | snyk-to-html -o results-iac.html`
 
 
-   **For Snyk Container
+   **For Snyk Container**
 
    Run the following line to create a file called `results-container.html`:
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,38 @@ When in doubt, use `snyk-to-html --help` or `snyk-to-html -h`.
 
 ## Generate the HTML report
 
-Change directory to your package's root folder, then use of the two ways below to generate the HTML report.
+Snyk JSON to HTML Mapper mapper works with the different Snyk Products.  Change directory to your package's root folder, then use  one of the  ways below to generate the HTML report, using the appropriate product's command
 
 1. Directly streaming the results to snyk-to-html:
 
-   Run the following line to create a file called `results.html`:
+   For Snyk Open Source
 
-   `snyk test --json | snyk-to-html -o results.html`
+   Run the following line to create a file called `results-opensource.html`:
+
+   `snyk test --json | snyk-to-html -o results-opensource.html`
+
+   For Snyk Code
+
+   Run the following line to create a file called `results-code.html`:
+
+   `snyk code test --json | snyk-to-html -o results-code.html`
+
+
+   For Snyk Infrastructure as Code (IaC)
+   Navigate to the subfolder with the related files.
+
+   Run the following line to create a file called `results-iac.html`:
+
+   `snyk iac test --json | snyk-to-html -o results-iac.html`
+
+
+   For Snyk Container
+
+   Run the following line to create a file called `results-container.html`:
+
+   `snyk container test [image] --json | snyk-to-html -o results-container.html`
+
+   The following methods/examples will utilize snyk test, however they will also work with the other product commands , as above.
 
 2. Using a temporary file:
 
@@ -83,7 +108,7 @@ Change directory to your package's root folder, then use of the two ways below t
 
 ## View the HTML report
 
-Simply open your new file (`results.html` above) in a browser, and rejoice.
+Simply open your new file (`results-[type].html` as above) in a browser, and rejoice.
 
 ### License
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Commits are squashed and tidy and are suitable to become release notes

### What this does

The current snyk-to-html plugin does not make it clear it works across products. This commit aims to fix this.

### Notes for the reviewer

This is my first commit ever at Snyk, please help me make sure it's done the right way. With my move to docs/customer journey there will be a lot more

### More information


### Screenshots


