### PR TITLE
fix/HEAD-308_add_timezone

### DIFF
--- a/template/code/test-report.header.hbs
+++ b/template/code/test-report.header.hbs
@@ -19,7 +19,7 @@
       </svg>
     </a>
     <div class="test-meta">
-      <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a"}}</p>
+      <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a (zZ)"}}</p>
       <div class="filepath" title="{{projects.[0].sourceFilePath}}">Source: {{projects.[0].sourceFilePath}}</div>
     </div>
   </div>

--- a/template/iac/test-report.header.hbs
+++ b/template/iac/test-report.header.hbs
@@ -18,7 +18,7 @@
               <h1 class="project__header__title">Snyk test summary</h1>
             {{/unless}}
 
-            <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a"}}</p>
+            <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a (zZ)"}}</p>
           </div>
           {{#if projects}}
             <div class="source-panel">

--- a/template/test-cve-report.hbs
+++ b/template/test-cve-report.hbs
@@ -597,7 +597,7 @@
           </a>
           <div class="header-wrap">
               <h1 class="project__header__title">Snyk test report</h1>
-              <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a"}}</p>
+              <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a (zZ)"}}</p>
           </div>
           {{#if paths}}
           <div class="source-panel">

--- a/template/test-report.header.hbs
+++ b/template/test-report.header.hbs
@@ -18,7 +18,7 @@
               <h1 class="project__header__title">Snyk test summary</h1>
             {{/unless}}
 
-            <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a"}}</p>
+            <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a (zZ)"}}</p>
           </div>
           {{#if paths}}
           <div class="source-panel">


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commits are squashed and tidy and are suitable to become release notes

### What this does
Add missing timezone information to the reports. The time was already in UTC, now this is being made visible.

Before: May 12th 2023, 9:13:03 am
Now: May 12th 2023, 9:13:03 am (UTC+00:00)
 