### PR TITLE
chore: update CODEOWNERS for IaC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @snyk/hammerhead
-template/iac/* @snyk/group-infrastructure-as-code
+template/iac/* @snyk/cloud-dev-ex
 template/code/* @snyk/zenith
 src/lib/codeutil.ts @snyk/zenith


### PR DESCRIPTION
Cloud-dev-ex owns the plugin, group-infrastructure-as-code is deprecated.