### PR TITLE
chore: update snyk iac rules URL with new site [APOLLO11-1173]

### DIFF
--- a/tap-snapshots/test-snyk-to-html.test.ts-TAP.test.js
+++ b/tap-snapshots/test-snyk-to-html.test.ts-TAP.test.js
@@ -526,7 +526,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-533">SNYK-CC-AZURE-533</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533">SNYK-CC-AZURE-533</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -548,7 +548,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-533">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -564,7 +564,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-619">SNYK-CC-AZURE-619</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-619">SNYK-CC-AZURE-619</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -586,7 +586,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-619">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-619">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -602,7 +602,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-625">SNYK-CC-AZURE-625</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-625">SNYK-CC-AZURE-625</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -624,7 +624,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-625">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-625">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -640,7 +640,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-624">SNYK-CC-AZURE-624</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-624">SNYK-CC-AZURE-624</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -662,7 +662,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-624">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-624">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -716,7 +716,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-149">SNYK-CC-TF-149</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-149">SNYK-CC-TF-149</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -738,7 +738,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-149">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-149">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -754,7 +754,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-618">SNYK-CC-AZURE-618</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-618">SNYK-CC-AZURE-618</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -776,7 +776,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-618">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-618">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -792,7 +792,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-163">SNYK-CC-TF-163</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-163">SNYK-CC-TF-163</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -814,7 +814,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-163">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-163">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -830,7 +830,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-161">SNYK-CC-TF-161</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-161">SNYK-CC-TF-161</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -852,7 +852,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-161">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-161">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -868,7 +868,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-162">SNYK-CC-TF-162</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-162">SNYK-CC-TF-162</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -890,7 +890,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-162">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-162">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -906,7 +906,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-136">SNYK-CC-TF-136</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-136">SNYK-CC-TF-136</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -925,7 +925,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-136">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-136">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -941,7 +941,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-175">SNYK-CC-TF-175</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-175">SNYK-CC-TF-175</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -961,7 +961,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-175">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-175">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -990,7 +990,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-533">SNYK-CC-AZURE-533</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533">SNYK-CC-AZURE-533</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1012,7 +1012,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-533">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1028,7 +1028,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-500">SNYK-CC-AZURE-500</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-500">SNYK-CC-AZURE-500</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1050,7 +1050,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-500">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-500">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1066,7 +1066,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-619">SNYK-CC-AZURE-619</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-619">SNYK-CC-AZURE-619</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1088,7 +1088,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-619">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-619">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1104,7 +1104,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-144">SNYK-CC-TF-144</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-144">SNYK-CC-TF-144</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1126,7 +1126,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-144">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-144">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1142,7 +1142,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-618">SNYK-CC-AZURE-618</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-618">SNYK-CC-AZURE-618</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1164,7 +1164,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-618">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-618">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1180,7 +1180,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-163">SNYK-CC-TF-163</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-163">SNYK-CC-TF-163</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1202,7 +1202,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-163">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-163">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1218,7 +1218,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-161">SNYK-CC-TF-161</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-161">SNYK-CC-TF-161</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1240,7 +1240,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-161">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-161">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1256,7 +1256,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-162">SNYK-CC-TF-162</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-162">SNYK-CC-TF-162</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1278,7 +1278,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-162">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-162">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1307,7 +1307,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-516">SNYK-CC-AZURE-516</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-516">SNYK-CC-AZURE-516</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1329,7 +1329,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-516">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-516">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1358,7 +1358,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-533">SNYK-CC-AZURE-533</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533">SNYK-CC-AZURE-533</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1380,7 +1380,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-533">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1396,7 +1396,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-500">SNYK-CC-AZURE-500</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-500">SNYK-CC-AZURE-500</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1418,7 +1418,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-500">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-500">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1434,7 +1434,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-619">SNYK-CC-AZURE-619</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-619">SNYK-CC-AZURE-619</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1456,7 +1456,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-619">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-619">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1472,7 +1472,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-144">SNYK-CC-TF-144</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-144">SNYK-CC-TF-144</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1494,7 +1494,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-144">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-144">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1510,7 +1510,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-AZURE-618">SNYK-CC-AZURE-618</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-618">SNYK-CC-AZURE-618</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1532,7 +1532,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-AZURE-618">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-618">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1548,7 +1548,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-163">SNYK-CC-TF-163</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-163">SNYK-CC-TF-163</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1570,7 +1570,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-163">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-163">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1586,7 +1586,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-161">SNYK-CC-TF-161</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-161">SNYK-CC-TF-161</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1608,7 +1608,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-161">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-161">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1624,7 +1624,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-162">SNYK-CC-TF-162</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-162">SNYK-CC-TF-162</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1646,7 +1646,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-162">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-162">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->
@@ -1675,7 +1675,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
               
                       <ul class="card__meta">
                           <li class="card__meta__item">
-                              Public ID: <a href="https://snyk.io/security-rules/SNYK-CC-TF-244">SNYK-CC-TF-244</a> 
+                              Public ID: <a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-244">SNYK-CC-TF-244</a> 
                           </li>
               
                           <li class="card__meta__item">Introduced through:
@@ -1697,7 +1697,7 @@ exports[`test/snyk-to-html.test.ts TAP IaC input - test snyk-to-html handles -s 
                   </div><!-- .card__section -->
               
                   <div class="cta card__cta">
-                      <p><a href="https://snyk.io/security-rules/SNYK-CC-TF-244">More about this issue</a></p>
+                      <p><a href="https://security.snyk.io/rules/cloud//SNYK-CC-TF-244">More about this issue</a></p>
                   </div>
               
               </div><!-- .card -->

--- a/test/fixtures/iac-test-report.json
+++ b/test/fixtures/iac-test-report.json
@@ -100,7 +100,7 @@
           "resolve": "Set `logging.enable` attribute to `true`"
         },
         "lineNumber": -1,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-136",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-136",
         "isGeneratedByCustomRule": false,
         "path": [
           "resource",
@@ -157,7 +157,7 @@
           "resolve": "Set `properties.clientCertEnabled` attribute to `true`"
         },
         "lineNumber": 109,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-162",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-162",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[3]",
@@ -191,7 +191,7 @@
           "resolve": "Set `properties.enablePurgeProtection` to `true`"
         },
         "lineNumber": 184,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-624",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-624",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[5]",
@@ -223,7 +223,7 @@
           "resolve": "Set `properties.minimumTlsVersion`  attribute to `TLS1_2`"
         },
         "lineNumber": 62,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-149",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-149",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[0]",
@@ -257,7 +257,7 @@
           "resolve": "Set `properties.enableSoftDelete` to `true`"
         },
         "lineNumber": 184,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-625",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-625",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[5]",
@@ -290,7 +290,7 @@
           "resolve": "Set `properties.enablePurgeProtection` attribute to `true`, and `properties.enableSoftDelete` attribute to `true`"
         },
         "lineNumber": 184,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-175",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-175",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[5]",
@@ -323,7 +323,7 @@
           "resolve": "Set `identity` attribute"
         },
         "lineNumber": 103,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-161",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-161",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[3]",
@@ -355,7 +355,7 @@
           "resolve": "Set `sku.capacity` to `2` or more"
         },
         "lineNumber": 98,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-618",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-618",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[2]",
@@ -389,7 +389,7 @@
           "resolve": "Set `ftpsState` to `FtpsOnly` or `Disabled` if not needed"
         },
         "lineNumber": 109,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-533",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[3]",
@@ -421,7 +421,7 @@
           "resolve": "Set `properties.siteConfig.http20Enabled` attribute to `true`"
         },
         "lineNumber": 111,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-163",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-163",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[3]",
@@ -453,7 +453,7 @@
           "resolve": "Set `properties.remoteDebuggingEnabled` to `false`"
         },
         "lineNumber": 109,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-619",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-619",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[3]",
@@ -512,7 +512,7 @@
           "resolve": "Set `sku.capacity` to `2` or more"
         },
         "lineNumber": 48,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-618",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-618",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[0]",
@@ -544,7 +544,7 @@
           "resolve": "Set `properties.remoteDebuggingEnabled` to `false`"
         },
         "lineNumber": 58,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-619",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-619",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -577,7 +577,7 @@
           "resolve": "Set `properties.clientCertEnabled` attribute to `true`"
         },
         "lineNumber": 58,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-162",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-162",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -610,7 +610,7 @@
           "resolve": "Set `httpsOnly` attribute to `true`"
         },
         "lineNumber": 58,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-500",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-500",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -644,7 +644,7 @@
           "resolve": "Set `identity` attribute"
         },
         "lineNumber": 53,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-161",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-161",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -676,7 +676,7 @@
           "resolve": "Set `properties.siteConfig.http20Enabled` attribute to `true`"
         },
         "lineNumber": 58,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-163",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-163",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -710,7 +710,7 @@
           "resolve": "Set `ftpsState` to `FtpsOnly` or `Disabled` if not needed"
         },
         "lineNumber": 58,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-533",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -743,7 +743,7 @@
           "resolve": "Set `properties.httpsOnly` attribute to `true`"
         },
         "lineNumber": 58,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-144",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-144",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -803,7 +803,7 @@
           "resolve": "Set `properties.enableDdosProtection` to `true`"
         },
         "lineNumber": 98,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-516",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-516",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[0]",
@@ -862,7 +862,7 @@
           "resolve": "Set `sku.capacity` to `2` or more"
         },
         "lineNumber": 129,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-618",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-618",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[0]",
@@ -894,7 +894,7 @@
           "resolve": "Set `properties.remoteDebuggingEnabled` to `false`"
         },
         "lineNumber": 139,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-619",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-619",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -927,7 +927,7 @@
           "resolve": "Set `properties.clientCertEnabled` attribute to `true`"
         },
         "lineNumber": 139,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-162",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-162",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -960,7 +960,7 @@
           "resolve": "Set `httpsOnly` attribute to `true`"
         },
         "lineNumber": 139,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-500",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-500",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -994,7 +994,7 @@
           "resolve": "Set `identity` attribute"
         },
         "lineNumber": 134,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-161",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-161",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -1026,7 +1026,7 @@
           "resolve": "Set `properties.siteConfig.http20Enabled` attribute to `true`"
         },
         "lineNumber": 139,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-163",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-163",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -1060,7 +1060,7 @@
           "resolve": "Set `ftpsState` to `FtpsOnly` or `Disabled` if not needed"
         },
         "lineNumber": 139,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-AZURE-533",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -1093,7 +1093,7 @@
           "resolve": "Set `properties.httpsOnly` attribute to `true`"
         },
         "lineNumber": 139,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-144",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-144",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[1]",
@@ -1152,7 +1152,7 @@
           "resolve": "Set `properties.supportsHttpsTrafficOnly` attribute to `true`"
         },
         "lineNumber": 86,
-        "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-244",
+        "documentation": "https://security.snyk.io/rules/cloud//SNYK-CC-TF-244",
         "isGeneratedByCustomRule": false,
         "path": [
           "resources[2]",

--- a/test/snyk-to-html.test.ts
+++ b/test/snyk-to-html.test.ts
@@ -742,12 +742,12 @@ test('IaC input - all-around test', (t) => {
       );
       t.contains(
         report,
-        '<a href="https://snyk.io/security-rules/SNYK-CC-AZURE-533">More about this issue</a>',
+        '<a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533">More about this issue</a>',
         'should contain a link to the security rules site',
       );
       t.contains(
         report,
-        '<a href="https://snyk.io/security-rules/SNYK-CC-AZURE-533">SNYK-CC-AZURE-533</a>',
+        '<a href="https://security.snyk.io/rules/cloud//SNYK-CC-AZURE-533">SNYK-CC-AZURE-533</a>',
         'should contain public ID of the issue',
       );
       t.contains(


### PR DESCRIPTION
Updating all URLs for IaC rules from https://snyk.io/security-rules to https://security.snyk.io/rules/cloud/, as all the rules are now hosted there. The old site is deprecated, and everything is redirected already to the new one.