### PR TITLE
fix: include default `max_old_space_size` in binaries [HEAD-1045]

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,7 @@
     {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg && pkg . --options max_old_space_size=16384 -t node14-alpine-x64,node14-linux-x64,node14-macos-x64,node14-win-x64"
+      "cmd": "npm i -g pkg@5.8.1 && pkg . --options max_old_space_size=16384 -t node14-alpine-x64,node14-linux-x64,node14-macos-x64,node14-win-x64"
     },
     {
       "//": "shasum all binaries",

--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,7 @@
     {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg && pkg . -t node14-alpine-x64,node14-linux-x64,node14-macos-x64,node14-win-x64"
+      "cmd": "npm i -g pkg && pkg . --options max_old_space_size=16384 -t node14-alpine-x64,node14-linux-x64,node14-macos-x64,node14-win-x64"
     },
     {
       "//": "shasum all binaries",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Commits are squashed and tidy and are suitable to become release notes

### What this does

This PR introduces a change in the packaging command for our binaries to specify a default maximum old space size for V8's memory. The change was prompted by the need to accommodate larger projects that may require more memory than the default settings allow.

A change in the `pkg-fetch` repository (see [vercel/pkg-fetch@7f3403b](https://github.com/vercel/pkg-fetch/commit/7f3403bd71d244850ef30a711c52e64f905e9423)) disabled the `NODE_OPTIONS` environment variable, which previously allowed consumers to set Node.js runtime options, including `--max-old-space-size`, at runtime. This has impacted users who need to increase the memory limit beyond the default when running the `snyk-to-html` tool.

Given that we cannot rely on `NODE_OPTIONS`, this PR takes the approach of setting a conservative default memory limit at build time using the `--options max_old_space_size=16384` flag. This will set the old space size to 16GB, which should suffice for the majority of use cases without manual intervention. 


### Notes for the reviewer

To be able to test this change I added a log like the following:

```ts
async function main() {
  console.log(
    'Heap size limit:',
    v8.getHeapStatistics().heap_size_limit / 1024 / 1024,
    'MB',
  );
}
```

and we can see the output in the following image:

<img width="1354" alt="test" src="https://github.com/snyk/snyk-to-html/assets/1948377/ffa71749-b261-4f36-8303-f0a55219d7dc">

### More information

HEAD-1045
HEAD-1051