### PR TITLE
Add descriptor for non-supported coverage and fix duplicate languages

### DIFF
--- a/template/code/test-report.hbs
+++ b/template/code/test-report.hbs
@@ -48,7 +48,7 @@
         {{#if projects.[0].details.coverage}}
           <span class="source-panel__heading">Scan Coverage</span>
           <ul class="scan-coverage">
-            {{#each projects.[0].details.coverage}}<li class="type">{{this.lang}} files: <strong>{{this.files}}</strong></li>{{/each}}
+            {{#each projects.[0].details.coverage}}<li class="type">{{this.lang}}{{#unless this.isSupported }}[{{this.type}}]{{/unless}} files: <strong>{{this.files}}</strong></li> {{/each}}
           </ul>            
         {{/if}}
         {{/if}}


### PR DESCRIPTION
### What this does

Right now coverage blocks where isSupported=False and type=FAILED_PARSING end up in the coverage section of the report and cannot be differentiated from success. This change just adds the type of coverage in brackets if isSupported is false. 

Example input snippet:
```json
"properties": {
        "coverage": [
          {
            "isSupported": true,
            "lang": "XML",
            "files": 3,
            "type": "SUPPORTED"
          },
          {
            "isSupported": true,
            "lang": "HTML",
            "files": 13,
            "type": "SUPPORTED"
          },
          {
            "isSupported": true,
            "lang": "Java",
            "files": 39,
            "type": "SUPPORTED"
          },
          {
            "isSupported": false,
            "lang": "Java",
            "files": 1,
            "type": "FAILED_PARSING"
          }
        ]
      }
```

Right now it renders as

<img width="1235" alt="image" src="https://github.com/snyk/snyk-to-html/assets/4860914/68b7f915-fd15-4935-987e-edd549480667">


After this PR it renders as:
<img width="1248" alt="image" src="https://github.com/snyk/snyk-to-html/assets/4860914/16b03e81-133d-4155-a94e-1ef0e86ece29">

Here is an example file with a file that has failed to parse:
[test.json](https://github.com/snyk/snyk-to-html/files/14655273/test.json)
