### PR TITLE
chore: increase max_old_space_size in binaries

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [12, 14, 16, 18, 20]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,7 @@
     {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg@5.8.1 && pkg . --options max_old_space_size=16384 -t node14-alpine-x64,node14-linux-x64,node14-macos-x64,node14-win-x64"
+      "cmd": "npm i -g pkg@5.8.1 && pkg . --options max_old_space_size=32768 -t node14-alpine-x64,node14-linux-x64,node14-macos-x64,node14-win-x64"
     },
     {
       "//": "shasum all binaries",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commits are squashed and tidy and are suitable to become release notes

### What this does

This PR increases the `max_old_space_size` node option, increasing the heap memory in the compiled binary. This should reduce the number of JS Heap OOM errors that may be encounterd.