### PR TITLE
chore: add compression for build artefacts

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -18,7 +18,7 @@
     {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg@5.8.1 && pkg . --options max_old_space_size=32768 -t node14-alpine-x64,node14-linux-x64,node14-macos-x64,node14-win-x64"
+      "cmd": "npm i -g pkg@5.8.1 && pkg . --compress Brotli --options max_old_space_size=32768 -t node14-alpine-x64,node14-linux-x64,node14-macos-x64,node14-win-x64"
     },
     {
       "//": "shasum all binaries",


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commits are squashed and tidy and are suitable to become release notes

### What this does

This PR updates the `.releaserc` configuration to include Brotli compression for the generated binaries. The primary purpose is to optimize the binary sizes for different platforms (Alpine, macOS, Linux, and Windows) without compromising performance, which may lead to quicker download and deployment times for the end users.

Example of differences:

* Before: Linux – 47.840.380 bytes
* After: Linux – 39.993.548 bytes
* Savings: ~17%

### Notes for the reviewer

To test this update locally:
1. Run `npm i -g pkg@5.8.1` to ensure the correct version of `pkg` is installed.
2. Execute the modified command to build the binaries with Brotli compression:
   ```
   pkg . --compress Brotli --options max_old_space_size=32768 -t node14-alpine-x64,node14-linux-x64,node14-macos-x64,node14-win-x64
   ```
3. Confirm that the compressed binaries are generated and verify their functionality on each target platform if possible.

**Please check** that the binary sizes are reduced and that no unexpected issues arise during execution with the compressed binaries.

### More information

- [Link to issue](#)

### Screenshots

_No visuals for this configuration change._
