### PR TITLE
Timezone support pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ node ./dist/index.js
 | `-s`  | `--summary`                | Generates an HTML with only the summary, instead of the details report. Defaults to details vulnerability report |
 | `-d`  | `--debug`                  | Runs the CLI in debug mode                                                                                       |
 | `-a`  | `--actionable-remediation` | Display actionable remediation info if available                                                                 |
-
+| `-z`  | `--timezone`               | Set the timezone explicitely (i.e. Europe/Rome). Defaults to UTC                                                 |
 When in doubt, use `snyk-to-html --help` or `snyk-to-html -h`.
 
 ## Generate the HTML report

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.orderby": "^4.6.0",
     "marked": "^4.0.12",
+    "moment-timezone": "^0.5.47",
     "source-map-support": "^0.5.16",
     "uglify-js": "^3.15.1"
   },

--- a/results-code.html
+++ b/results-code.html
@@ -1,0 +1,492 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+  <meta http-equiv="Content-Language" content="en-us">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Snyk test report</title>
+  <meta name="description" content="0 known vulnerabilities found in 0 vulnerable dependency paths.">
+  <base target="_blank">
+  <link rel="icon" type="image/png" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.png"
+    sizes="194x194">
+  <link rel="shortcut icon" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.ico">
+  <style type="text/css">
+  
+    body {
+      -moz-font-feature-settings: "pnum";
+      -webkit-font-feature-settings: "pnum";
+      font-variant-numeric: proportional-nums;
+      display: flex;
+      flex-direction: column;
+      font-feature-settings: "pnum";
+      font-size: 100%;
+      line-height: 1.5;
+      min-height: 100vh;
+      -webkit-text-size-adjust: 100%;
+      margin: 0;
+      padding: 0;
+      background-color: #F5F5F5;
+      font-family: 'Arial', 'Helvetica', Calibri, sans-serif;
+    }
+  
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      font-weight: 500;
+    }
+  
+    a,
+    a:link,
+    a:visited {
+      border-bottom: 1px solid #4b45a9;
+      text-decoration: none;
+      color: #4b45a9;
+    }
+  
+    a:hover,
+    a:focus,
+    a:active {
+      border-bottom: 1px solid #4b45a9;
+    }
+  
+    hr {
+      border: none;
+      margin: 1em 0;
+      border-top: 1px solid #c5c5c5;
+    }
+  
+    ul {
+      padding: 0 1em;
+      margin: 1em 0;
+    }
+  
+    code {
+      background-color: #EEE;
+      color: #333;
+      padding: 0.25em 0.5em;
+      border-radius: 0.25em;
+    }
+  
+    pre {
+      background-color: #333;
+      font-family: monospace;
+      padding: 0.5em 1em 0.75em;
+      border-radius: 0.25em;
+      font-size: 14px;
+    }
+  
+    pre code {
+      padding: 0;
+      background-color: transparent;
+      color: #fff;
+    }
+  
+    a code {
+      border-radius: .125rem .125rem 0 0;
+      padding-bottom: 0;
+      color: #4b45a9;
+    }
+  
+    a[href^="http://"]:after,
+    a[href^="https://"]:after {
+      background-image: linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20id%3D%22Page-1%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20id%3D%22link-external%22%3E%3Cg%20id%3D%22arrow%22%3E%3Cpath%20id%3D%22Line%22%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20id%3D%22Triangle%22%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20id%3D%22square%22%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+      background-repeat: no-repeat;
+      background-size: .75rem;
+      content: "";
+      display: inline-block;
+      height: .75rem;
+      margin-left: .25rem;
+      width: .75rem;
+    }
+  
+  
+  /* Layout */
+  
+    [class*=layout-container] {
+      margin: 0 auto;
+      max-width: 71.25em;
+      padding: 1.9em 1.3em;
+      position: relative;
+    }
+    .layout-container--short {
+      padding-top: 0;
+      padding-bottom: 0;
+      max-width: 48.75em;
+    }
+  
+    .layout-container--short:after {
+      display: block;
+      content: "";
+      clear: both;
+    }
+  
+  /* Header */
+  
+    .header {
+      padding-bottom: 1px;
+    }
+  
+    .paths {
+      margin-left: 8px;
+    }
+    .header-wrap {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      padding-top: 2em;
+    }
+    .project__header {
+      background-color: #4b45a9;
+      color: #fff;
+      margin-bottom: -1px;
+      padding-top: 1em;
+      padding-bottom: 0.25em;
+      border-bottom: 2px solid #BBB;
+    }
+  
+    .project__header__title {
+      overflow-wrap: break-word;
+      word-wrap: break-word;
+      word-break: break-all;
+      margin-bottom: .1em;
+      margin-top: 0;
+    }
+  
+    .timestamp {
+      float: right;
+      clear: none;
+      margin-bottom: 0;
+    }
+  
+    .meta-counts {
+      clear: both;
+      display: block;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      margin: 0 0 1.5em;
+      color: #fff;
+      clear: both;
+      font-size: 1.1em;
+    }
+  
+    .meta-count {
+      display: block;
+      flex-basis: 100%;
+      margin: 0 1em 1em 0;
+      float: left;
+      padding-right: 1em;
+      border-right: 2px solid #fff;
+    }
+  
+    .meta-count:last-child {
+      border-right: 0;
+      padding-right: 0;
+      margin-right: 0;
+    }
+  
+  /* Card */
+  
+    .card {
+      background-color: #fff;
+      border: 1px solid #c5c5c5;
+      border-radius: .25rem;
+      margin: 0 0 2em 0;
+      position: relative;
+      min-height: 40px;
+      padding: 1.5em;
+    }
+  
+    .card .label {
+      background-color: #767676;
+      border: 2px solid #767676;
+      color: white;
+      padding: 0.25rem 0.75rem;
+      font-size: 0.875rem;
+      text-transform: uppercase;
+      display: inline-block;
+      margin: 0;
+      border-radius: 0.25rem;
+    }
+  
+    .card .label__text {
+      vertical-align: text-top;
+        font-weight: bold;
+    }
+  
+    .card .label--critical {
+      background-color: #AB1A1A;
+      border-color: #AB1A1A;
+    }
+  
+    .card .label--high {
+      background-color: #CE5019;
+      border-color: #CE5019;
+    }
+  
+    .card .label--medium {
+      background-color: #D68000;
+      border-color: #D68000;
+    }
+  
+    .card .label--low {
+      background-color: #88879E;
+      border-color: #88879E;
+    }
+  
+    .severity--low {
+      border-color: #88879E;
+    }
+  
+    .severity--medium {
+      border-color: #D68000;
+    }
+  
+    .severity--high {
+      border-color: #CE5019;
+    }
+  
+    .severity--critical {
+      border-color: #AB1A1A;
+    }
+  
+    .card--vuln {
+      padding-top: 4em;
+    }
+  
+    .card--vuln .label {
+      left: 0;
+      position: absolute;
+      top: 1.1em;
+      padding-left: 1.9em;
+      padding-right: 1.9em;
+      border-radius: 0 0.25rem 0.25rem 0;
+    }
+  
+    .card--vuln .card__section h2 {
+      font-size: 22px;
+      margin-bottom: 0.5em;
+    }
+  
+    .card--vuln .card__section p {
+      margin: 0 0 0.5em 0;
+    }
+  
+    .card--vuln .card__meta {
+      padding: 0 0 0 1em;
+      margin: 0;
+      font-size: 1.1em;
+    }
+  
+    .card .card__meta__paths {
+      font-size: 0.9em;
+    }
+  
+    .card--vuln .card__title {
+      font-size: 28px;
+      margin-top: 0;
+    }
+  
+    .card--vuln .card__cta p {
+      margin: 0;
+      text-align: right;
+    }
+  
+    .source-panel {
+      clear: both;
+      display: flex;
+      justify-content: flex-start;
+      flex-direction: column;
+      align-items: flex-start;
+      padding: 0.5em 0;
+      width: fit-content;
+    }
+  
+  
+  
+  </style>
+  <style type="text/css">
+    .metatable {
+      text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -webkit-box-direction: normal;
+      color: inherit;
+      font-feature-settings: "pnum";
+      box-sizing: border-box;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      font-size: 100%;
+      margin: 0;
+      outline: none;
+      padding: 0;
+      text-align: left;
+      text-decoration: none;
+      vertical-align: baseline;
+      z-index: auto;
+      margin-top: 12px;
+      border-collapse: collapse;
+      border-spacing: 0;
+      font-variant-numeric: tabular-nums;
+      max-width: 51.75em;
+    }
+  
+    tbody {
+      text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -webkit-box-direction: normal;
+      color: inherit;
+      font-feature-settings: "pnum";
+      border-collapse: collapse;
+      border-spacing: 0;
+      box-sizing: border-box;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      font-size: 100%;
+      margin: 0;
+      outline: none;
+      padding: 0;
+      text-align: left;
+      text-decoration: none;
+      vertical-align: baseline;
+      z-index: auto;
+      display: flex;
+      flex-wrap: wrap;
+    }
+  
+    .meta-row {
+      text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -webkit-box-direction: normal;
+      color: inherit;
+      font-feature-settings: "pnum";
+      border-collapse: collapse;
+      border-spacing: 0;
+      box-sizing: border-box;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      font-size: 100%;
+      outline: none;
+      text-align: left;
+      text-decoration: none;
+      vertical-align: baseline;
+      z-index: auto;
+      display: flex;
+      align-items: start;
+      border-top: 1px solid #d3d3d9;
+      padding: 8px 0 0 0;
+      border-bottom: none;
+      margin: 8px;
+      width: 47.75%;
+    }
+  
+    .meta-row-label {
+      text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -webkit-box-direction: normal;
+      font-feature-settings: "pnum";
+      border-collapse: collapse;
+      border-spacing: 0;
+      color: #4c4a73;
+      box-sizing: border-box;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      margin: 0;
+      outline: none;
+      text-decoration: none;
+      z-index: auto;
+      align-self: start;
+      flex: 1;
+      font-size: 1rem;
+      line-height: 1.5rem;
+      padding: 0;
+      text-align: left;
+      vertical-align: top;
+      text-transform: none;
+      letter-spacing: 0;
+    }
+  
+    .meta-row-value {
+      text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -webkit-box-direction: normal;
+      color: inherit;
+      font-feature-settings: "pnum";
+      border-collapse: collapse;
+      border-spacing: 0;
+      word-break: break-word;
+      box-sizing: border-box;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      font-size: 100%;
+      margin: 0;
+      outline: none;
+      padding: 0;
+      text-align: right;
+      text-decoration: none;
+      vertical-align: baseline;
+      z-index: auto;
+    }
+  </style>
+</head>
+
+<body class="section-projects">
+  <main class="layout-stacked">
+        <div class="layout-stacked__header header">
+          <header class="project__header">
+            <div class="layout-container">
+              <a class="brand" href="https://snyk.io" title="Snyk">
+                <svg width="68px" height="35px" viewBox="0 0 68 35" version="1.1" xmlns="http://www.w3.org/2000/svg" role="img">
+                  <title>Snyk - Open Source Security</title>
+                  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                    <g fill="#fff">
+                      <path d="M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z"></path>
+                    </g>
+                  </g>
+                </svg>
+              </a>
+              <div class="header-wrap">
+                  <h1 class="project__header__title">Snyk test report</h1>
+    
+                <p class="timestamp">March 18th 2025, 7:40:56 pm (UTC+00:00)</p>
+              </div>
+              <div class="source-panel">
+                <span>Scanned the following path:</span>
+                <ul>
+                  <li class="paths">/Users/stephen/Documents/snyk-to-html-timezone ()</li>
+                </ul>
+              </div>
+    
+              <div class="meta-counts">
+                <div class="meta-count"><span>0</span> <span>known vulnerabilities</span></div>
+                <div class="meta-count"><span>0 vulnerable dependency paths</span></div>
+                <div class="meta-count"><span></span> <span>dependencies</span></div>
+              </div><!-- .meta-counts -->
+            </div><!-- .layout-container--short -->
+          </header><!-- .project__header -->
+        </div><!-- .layout-stacked__header -->
+      <section class="layout-container">
+          <table class="metatable">
+              <tbody>
+              
+              <tr class="meta-row"><th class="meta-row-label">Path</th> <td class="meta-row-value">/Users/stephen/Documents/snyk-to-html-timezone</td></tr>
+              
+              
+              </tbody>
+          </table>
+      </section>
+    <div class="layout-container" style="padding-top: 35px;">
+      No known vulnerabilities detected.
+    </div>
+  </main><!-- .layout-stacked__content -->
+</body>
+
+</html>

--- a/results-code.json
+++ b/results-code.json
@@ -1,0 +1,5 @@
+{
+  "ok": false,
+  "error": "Project not supported\nexit code: 3",
+  "path": "/Users/stephen/Documents/snyk-to-html-timezone"
+}

--- a/results-opensource.html
+++ b/results-opensource.html
@@ -456,7 +456,7 @@
               <div class="header-wrap">
                   <h1 class="project__header__title">Snyk test report</h1>
     
-                <p class="timestamp">March 18th 2025, 5:27:56 pm (UTC+00:00)</p>
+                <p class="timestamp">March 18th 2025, 6:03:43 pm (UTC+00:00)</p>
               </div>
               <div class="source-panel">
                 <span>Scanned the following path:</span>

--- a/results-opensource.html
+++ b/results-opensource.html
@@ -1,4 +1,3 @@
-Generated Report at 2025-MM-DD HH:57:04 with Timezone: America/New_York
 <!DOCTYPE html>
 <html lang="en">
 
@@ -457,7 +456,7 @@ Generated Report at 2025-MM-DD HH:57:04 with Timezone: America/New_York
               <div class="header-wrap">
                   <h1 class="project__header__title">Snyk test report</h1>
     
-                <p class="timestamp">March 19th 2025, 1:57:04 pm (EDT-04:00)</p>
+                <p class="timestamp">March 19th 2025, 2:46:56 pm (PDT-07:00)</p>
               </div>
               <div class="source-panel">
                 <span>Scanned the following path:</span>

--- a/results-opensource.html
+++ b/results-opensource.html
@@ -1,0 +1,492 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+  <meta http-equiv="Content-Language" content="en-us">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Snyk test report</title>
+  <meta name="description" content="0 known vulnerabilities found in 0 vulnerable dependency paths.">
+  <base target="_blank">
+  <link rel="icon" type="image/png" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.png"
+    sizes="194x194">
+  <link rel="shortcut icon" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.ico">
+  <style type="text/css">
+  
+    body {
+      -moz-font-feature-settings: "pnum";
+      -webkit-font-feature-settings: "pnum";
+      font-variant-numeric: proportional-nums;
+      display: flex;
+      flex-direction: column;
+      font-feature-settings: "pnum";
+      font-size: 100%;
+      line-height: 1.5;
+      min-height: 100vh;
+      -webkit-text-size-adjust: 100%;
+      margin: 0;
+      padding: 0;
+      background-color: #F5F5F5;
+      font-family: 'Arial', 'Helvetica', Calibri, sans-serif;
+    }
+  
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      font-weight: 500;
+    }
+  
+    a,
+    a:link,
+    a:visited {
+      border-bottom: 1px solid #4b45a9;
+      text-decoration: none;
+      color: #4b45a9;
+    }
+  
+    a:hover,
+    a:focus,
+    a:active {
+      border-bottom: 1px solid #4b45a9;
+    }
+  
+    hr {
+      border: none;
+      margin: 1em 0;
+      border-top: 1px solid #c5c5c5;
+    }
+  
+    ul {
+      padding: 0 1em;
+      margin: 1em 0;
+    }
+  
+    code {
+      background-color: #EEE;
+      color: #333;
+      padding: 0.25em 0.5em;
+      border-radius: 0.25em;
+    }
+  
+    pre {
+      background-color: #333;
+      font-family: monospace;
+      padding: 0.5em 1em 0.75em;
+      border-radius: 0.25em;
+      font-size: 14px;
+    }
+  
+    pre code {
+      padding: 0;
+      background-color: transparent;
+      color: #fff;
+    }
+  
+    a code {
+      border-radius: .125rem .125rem 0 0;
+      padding-bottom: 0;
+      color: #4b45a9;
+    }
+  
+    a[href^="http://"]:after,
+    a[href^="https://"]:after {
+      background-image: linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20id%3D%22Page-1%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20id%3D%22link-external%22%3E%3Cg%20id%3D%22arrow%22%3E%3Cpath%20id%3D%22Line%22%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20id%3D%22Triangle%22%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20id%3D%22square%22%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+      background-repeat: no-repeat;
+      background-size: .75rem;
+      content: "";
+      display: inline-block;
+      height: .75rem;
+      margin-left: .25rem;
+      width: .75rem;
+    }
+  
+  
+  /* Layout */
+  
+    [class*=layout-container] {
+      margin: 0 auto;
+      max-width: 71.25em;
+      padding: 1.9em 1.3em;
+      position: relative;
+    }
+    .layout-container--short {
+      padding-top: 0;
+      padding-bottom: 0;
+      max-width: 48.75em;
+    }
+  
+    .layout-container--short:after {
+      display: block;
+      content: "";
+      clear: both;
+    }
+  
+  /* Header */
+  
+    .header {
+      padding-bottom: 1px;
+    }
+  
+    .paths {
+      margin-left: 8px;
+    }
+    .header-wrap {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      padding-top: 2em;
+    }
+    .project__header {
+      background-color: #4b45a9;
+      color: #fff;
+      margin-bottom: -1px;
+      padding-top: 1em;
+      padding-bottom: 0.25em;
+      border-bottom: 2px solid #BBB;
+    }
+  
+    .project__header__title {
+      overflow-wrap: break-word;
+      word-wrap: break-word;
+      word-break: break-all;
+      margin-bottom: .1em;
+      margin-top: 0;
+    }
+  
+    .timestamp {
+      float: right;
+      clear: none;
+      margin-bottom: 0;
+    }
+  
+    .meta-counts {
+      clear: both;
+      display: block;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      margin: 0 0 1.5em;
+      color: #fff;
+      clear: both;
+      font-size: 1.1em;
+    }
+  
+    .meta-count {
+      display: block;
+      flex-basis: 100%;
+      margin: 0 1em 1em 0;
+      float: left;
+      padding-right: 1em;
+      border-right: 2px solid #fff;
+    }
+  
+    .meta-count:last-child {
+      border-right: 0;
+      padding-right: 0;
+      margin-right: 0;
+    }
+  
+  /* Card */
+  
+    .card {
+      background-color: #fff;
+      border: 1px solid #c5c5c5;
+      border-radius: .25rem;
+      margin: 0 0 2em 0;
+      position: relative;
+      min-height: 40px;
+      padding: 1.5em;
+    }
+  
+    .card .label {
+      background-color: #767676;
+      border: 2px solid #767676;
+      color: white;
+      padding: 0.25rem 0.75rem;
+      font-size: 0.875rem;
+      text-transform: uppercase;
+      display: inline-block;
+      margin: 0;
+      border-radius: 0.25rem;
+    }
+  
+    .card .label__text {
+      vertical-align: text-top;
+        font-weight: bold;
+    }
+  
+    .card .label--critical {
+      background-color: #AB1A1A;
+      border-color: #AB1A1A;
+    }
+  
+    .card .label--high {
+      background-color: #CE5019;
+      border-color: #CE5019;
+    }
+  
+    .card .label--medium {
+      background-color: #D68000;
+      border-color: #D68000;
+    }
+  
+    .card .label--low {
+      background-color: #88879E;
+      border-color: #88879E;
+    }
+  
+    .severity--low {
+      border-color: #88879E;
+    }
+  
+    .severity--medium {
+      border-color: #D68000;
+    }
+  
+    .severity--high {
+      border-color: #CE5019;
+    }
+  
+    .severity--critical {
+      border-color: #AB1A1A;
+    }
+  
+    .card--vuln {
+      padding-top: 4em;
+    }
+  
+    .card--vuln .label {
+      left: 0;
+      position: absolute;
+      top: 1.1em;
+      padding-left: 1.9em;
+      padding-right: 1.9em;
+      border-radius: 0 0.25rem 0.25rem 0;
+    }
+  
+    .card--vuln .card__section h2 {
+      font-size: 22px;
+      margin-bottom: 0.5em;
+    }
+  
+    .card--vuln .card__section p {
+      margin: 0 0 0.5em 0;
+    }
+  
+    .card--vuln .card__meta {
+      padding: 0 0 0 1em;
+      margin: 0;
+      font-size: 1.1em;
+    }
+  
+    .card .card__meta__paths {
+      font-size: 0.9em;
+    }
+  
+    .card--vuln .card__title {
+      font-size: 28px;
+      margin-top: 0;
+    }
+  
+    .card--vuln .card__cta p {
+      margin: 0;
+      text-align: right;
+    }
+  
+    .source-panel {
+      clear: both;
+      display: flex;
+      justify-content: flex-start;
+      flex-direction: column;
+      align-items: flex-start;
+      padding: 0.5em 0;
+      width: fit-content;
+    }
+  
+  
+  
+  </style>
+  <style type="text/css">
+    .metatable {
+      text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -webkit-box-direction: normal;
+      color: inherit;
+      font-feature-settings: "pnum";
+      box-sizing: border-box;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      font-size: 100%;
+      margin: 0;
+      outline: none;
+      padding: 0;
+      text-align: left;
+      text-decoration: none;
+      vertical-align: baseline;
+      z-index: auto;
+      margin-top: 12px;
+      border-collapse: collapse;
+      border-spacing: 0;
+      font-variant-numeric: tabular-nums;
+      max-width: 51.75em;
+    }
+  
+    tbody {
+      text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -webkit-box-direction: normal;
+      color: inherit;
+      font-feature-settings: "pnum";
+      border-collapse: collapse;
+      border-spacing: 0;
+      box-sizing: border-box;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      font-size: 100%;
+      margin: 0;
+      outline: none;
+      padding: 0;
+      text-align: left;
+      text-decoration: none;
+      vertical-align: baseline;
+      z-index: auto;
+      display: flex;
+      flex-wrap: wrap;
+    }
+  
+    .meta-row {
+      text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -webkit-box-direction: normal;
+      color: inherit;
+      font-feature-settings: "pnum";
+      border-collapse: collapse;
+      border-spacing: 0;
+      box-sizing: border-box;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      font-size: 100%;
+      outline: none;
+      text-align: left;
+      text-decoration: none;
+      vertical-align: baseline;
+      z-index: auto;
+      display: flex;
+      align-items: start;
+      border-top: 1px solid #d3d3d9;
+      padding: 8px 0 0 0;
+      border-bottom: none;
+      margin: 8px;
+      width: 47.75%;
+    }
+  
+    .meta-row-label {
+      text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -webkit-box-direction: normal;
+      font-feature-settings: "pnum";
+      border-collapse: collapse;
+      border-spacing: 0;
+      color: #4c4a73;
+      box-sizing: border-box;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      margin: 0;
+      outline: none;
+      text-decoration: none;
+      z-index: auto;
+      align-self: start;
+      flex: 1;
+      font-size: 1rem;
+      line-height: 1.5rem;
+      padding: 0;
+      text-align: left;
+      vertical-align: top;
+      text-transform: none;
+      letter-spacing: 0;
+    }
+  
+    .meta-row-value {
+      text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -webkit-box-direction: normal;
+      color: inherit;
+      font-feature-settings: "pnum";
+      border-collapse: collapse;
+      border-spacing: 0;
+      word-break: break-word;
+      box-sizing: border-box;
+      background: transparent;
+      border: 0;
+      font: inherit;
+      font-size: 100%;
+      margin: 0;
+      outline: none;
+      padding: 0;
+      text-align: right;
+      text-decoration: none;
+      vertical-align: baseline;
+      z-index: auto;
+    }
+  </style>
+</head>
+
+<body class="section-projects">
+  <main class="layout-stacked">
+        <div class="layout-stacked__header header">
+          <header class="project__header">
+            <div class="layout-container">
+              <a class="brand" href="https://snyk.io" title="Snyk">
+                <svg width="68px" height="35px" viewBox="0 0 68 35" version="1.1" xmlns="http://www.w3.org/2000/svg" role="img">
+                  <title>Snyk - Open Source Security</title>
+                  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                    <g fill="#fff">
+                      <path d="M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z"></path>
+                    </g>
+                  </g>
+                </svg>
+              </a>
+              <div class="header-wrap">
+                  <h1 class="project__header__title">Snyk test report</h1>
+    
+                <p class="timestamp">March 6th 2025, 2:53:12 pm (undefined-05:00)</p>
+              </div>
+              <div class="source-panel">
+                <span>Scanned the following path:</span>
+                <ul>
+                  <li class="paths">/Users/stephen/Documents/snyk-to-html-timezone/package.json (npm)</li>
+                </ul>
+              </div>
+    
+              <div class="meta-counts">
+                <div class="meta-count"><span>0</span> <span>known vulnerabilities</span></div>
+                <div class="meta-count"><span>0 vulnerable dependency paths</span></div>
+                <div class="meta-count"><span>23</span> <span>dependencies</span></div>
+              </div><!-- .meta-counts -->
+            </div><!-- .layout-container--short -->
+          </header><!-- .project__header -->
+        </div><!-- .layout-stacked__header -->
+      <section class="layout-container">
+          <table class="metatable">
+              <tbody>
+              <tr class="meta-row"><th class="meta-row-label">Project</th> <td class="meta-row-value">snyk-to-html</td></tr>
+              <tr class="meta-row"><th class="meta-row-label">Path</th> <td class="meta-row-value">/Users/stephen/Documents/snyk-to-html-timezone</td></tr>
+              <tr class="meta-row"><th class="meta-row-label">Package Manager</th> <td class="meta-row-value">npm</td></tr>
+              <tr class="meta-row"><th class="meta-row-label">Manifest</th> <td class="meta-row-value">package.json</td></tr>
+              </tbody>
+          </table>
+      </section>
+    <div class="layout-container" style="padding-top: 35px;">
+      No known vulnerabilities detected.
+    </div>
+  </main><!-- .layout-stacked__content -->
+</body>
+
+</html>

--- a/results-opensource.html
+++ b/results-opensource.html
@@ -456,7 +456,7 @@
               <div class="header-wrap">
                   <h1 class="project__header__title">Snyk test report</h1>
     
-                <p class="timestamp">March 6th 2025, 2:53:12 pm (undefined-05:00)</p>
+                <p class="timestamp">March 18th 2025, 11:22:43 am (undefined-04:00)</p>
               </div>
               <div class="source-panel">
                 <span>Scanned the following path:</span>

--- a/results-opensource.html
+++ b/results-opensource.html
@@ -1,3 +1,4 @@
+Generated Report with Timezone: Europe/Rome
 <!DOCTYPE html>
 <html lang="en">
 
@@ -456,7 +457,7 @@
               <div class="header-wrap">
                   <h1 class="project__header__title">Snyk test report</h1>
     
-                <p class="timestamp">March 18th 2025, 6:03:43 pm (UTC+00:00)</p>
+                <p class="timestamp">March 19th 2025, 4:33:42 pm (UTC+00:00)</p>
               </div>
               <div class="source-panel">
                 <span>Scanned the following path:</span>

--- a/results-opensource.html
+++ b/results-opensource.html
@@ -1,4 +1,4 @@
-Generated Report with Timezone: Europe/Rome
+Generated Report at 2025-MM-DD HH:57:04 with Timezone: America/New_York
 <!DOCTYPE html>
 <html lang="en">
 
@@ -457,7 +457,7 @@ Generated Report with Timezone: Europe/Rome
               <div class="header-wrap">
                   <h1 class="project__header__title">Snyk test report</h1>
     
-                <p class="timestamp">March 19th 2025, 4:33:42 pm (UTC+00:00)</p>
+                <p class="timestamp">March 19th 2025, 1:57:04 pm (EDT-04:00)</p>
               </div>
               <div class="source-panel">
                 <span>Scanned the following path:</span>

--- a/results-opensource.html
+++ b/results-opensource.html
@@ -456,7 +456,7 @@
               <div class="header-wrap">
                   <h1 class="project__header__title">Snyk test report</h1>
     
-                <p class="timestamp">March 18th 2025, 11:22:43 am (undefined-04:00)</p>
+                <p class="timestamp">March 18th 2025, 5:27:56 pm (UTC+00:00)</p>
               </div>
               <div class="source-panel">
                 <span>Scanned the following path:</span>

--- a/results.json
+++ b/results.json
@@ -1,0 +1,32 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 23,
+  "org": "java-goof-bitbucket-fix",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": "Ensure attribution is in place for this license. Please see intranet.perciballi.ca/legal/GPL for approved text."
+      }
+    }
+  },
+  "packageManager": "npm",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false,
+    "autoApproveIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": true,
+  "uniqueCount": 0,
+  "projectName": "snyk-to-html",
+  "displayTargetFile": "package.json",
+  "hasUnknownVersions": false,
+  "path": "/Users/stephen/Documents/snyk-to-html-timezone"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,9 +45,8 @@ let timezone = program.timezone;
 if (!timezone || typeof timezone === 'boolean') {
   timezone = 'UTC+00:00'; // Default timezone if not provided or if flag is used without value
 }
-console.log(`Timezone argument received from index.ts: ${timezone}`);
 const formattedDate = formatDateTime(date, format, timezone);
-console.log(formattedDate);
+console.log(`Timezone from index.ts ${formattedDate}`);
 
 if (program.template) {
   // template

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import debugModule = require('debug');
 import fs = require('fs');
 import path = require('path');
 import { SnykToHtml } from './lib/snyk-to-html';
+import { formatDateTime } from './lib/dateutil';
 
 program
   .option(
@@ -28,11 +29,21 @@ program
     '-a, --actionable-remediation',
     'Display actionable remediation info if available',
   )
+  .option(
+    '-z, --timezone <timezone>',
+    'Specify timezone for dates (e.g., "UTC+02:00"). Defaults to UTC+00:00',
+  )
   .parse(process.argv);
 
 let template;
 let source;
 let output;
+// let timezone = 'UTC+00:00'; // Default timezone
+let timezone = program.timezone;
+if (!timezone) {
+  timezone = 'UTC'; // default to EST if no timezone is provided
+}
+
 
 if (program.template) {
   // template
@@ -65,6 +76,13 @@ if (program.output) {
     output = undefined;
   }
 }
+if (program.timezone) {
+  // timezone
+  timezone = program.timezone;
+  if (typeof timezone === 'boolean') {
+    timezone = 'UTC+00:00'; // Default if -z is used without a value
+  }
+}
 
 if (program.debug) {
   const nameSpace = 'snyk-to-html';
@@ -79,6 +97,7 @@ SnykToHtml.run(
   template,
   !!program.summary,
   onReportOutput,
+  timezone,
 );
 
 function onReportOutput(report: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import fs = require('fs');
 import path = require('path');
 import { SnykToHtml } from './lib/snyk-to-html';
 import { formatDateTime } from './lib/dateutil';
+const date = new Date(); // Use the current date, or any date you want to format
+const format = 'MMMM Do YYYY, h:mm:ss a'; // Example format: March 18th 2025, 4:35:56 pm
 
 program
   .option(
@@ -43,7 +45,9 @@ let timezone = program.timezone;
 if (!timezone || typeof timezone === 'boolean') {
   timezone = 'UTC+00:00'; // Default timezone if not provided or if flag is used without value
 }
-
+console.log(`Timezone argument received from index.ts: ${timezone}`);
+const formattedDate = formatDateTime(date, format, timezone);
+console.log(formattedDate);
 
 if (program.template) {
   // template

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,6 @@ if (!timezone || typeof timezone === 'boolean') {
   timezone = 'UTC+00:00'; // Default timezone if not provided or if flag is used without value
 }
 const formattedDate = formatDateTime(date, format, timezone);
-console.log(`Timezone from index.ts ${formattedDate}`);
 
 if (program.template) {
   // template

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,10 +38,10 @@ program
 let template;
 let source;
 let output;
-// let timezone = 'UTC+00:00'; // Default timezone
 let timezone = program.timezone;
-if (!timezone) {
-  timezone = 'UTC'; // default to EST if no timezone is provided
+
+if (!timezone || typeof timezone === 'boolean') {
+  timezone = 'UTC+00:00'; // Default timezone if not provided or if flag is used without value
 }
 
 
@@ -76,13 +76,7 @@ if (program.output) {
     output = undefined;
   }
 }
-if (program.timezone) {
-  // timezone
-  timezone = program.timezone;
-  if (typeof timezone === 'boolean') {
-    timezone = 'UTC+00:00'; // Default if -z is used without a value
-  }
-}
+
 
 if (program.debug) {
   const nameSpace = 'snyk-to-html';

--- a/src/lib/dateutil.ts
+++ b/src/lib/dateutil.ts
@@ -1,7 +1,7 @@
 import * as moment from 'moment-timezone';
 
 export function formatDateTime(date: Date | string | undefined, format: string, timezone: string = 'UTC'): string {
-    console.log(`Timezone received from CLI: ${timezone}`);
+    console.log(`Timezone received from CLI in dateutil: ${timezone}`);
 
     if (!date) {
         date = new Date(); // Use current date if none provided
@@ -34,7 +34,7 @@ export function formatDateTime(date: Date | string | undefined, format: string, 
         zonedDate = moment.tz(date, 'UTC');
     }
 
-    console.log(`Formatting date: ${zonedDate.format('YYYY-MM-DD HH:mm:ss')}, Timezone: ${timezone}, Output: ${zonedDate.format(format)}`);
+    console.log(`Formatting date in dateutil: ${zonedDate.format('YYYY-MM-DD HH:mm:ss')}, Timezone: ${timezone}, Output: ${zonedDate.format(format)}`);
 
     // Construct replacements, ensuring timezone context
     const replacements = {

--- a/src/lib/dateutil.ts
+++ b/src/lib/dateutil.ts
@@ -1,8 +1,6 @@
 import * as moment from 'moment-timezone';
 
 export function formatDateTime(date: Date | string | undefined, format: string, timezone: string = 'UTC'): string {
-    console.log(`Timezone received from CLI in dateutil: ${timezone}`);
-
     if (!date) {
         date = new Date(); // Use current date if none provided
     }
@@ -34,9 +32,6 @@ export function formatDateTime(date: Date | string | undefined, format: string, 
         zonedDate = moment.tz(date, 'UTC');
     }
 
-    console.log(`Formatting date in dateutil: ${zonedDate.format('YYYY-MM-DD HH:mm:ss')}, Timezone: ${timezone}, Output: ${zonedDate.format(format)}`);
-
-    // Construct replacements, ensuring timezone context
     const replacements = {
         'MMMM': zonedDate.format('MMMM'),
         'Do': zonedDate.format('Do'),
@@ -49,7 +44,6 @@ export function formatDateTime(date: Date | string | undefined, format: string, 
         'Z': zonedDate.format('Z')
     };
 
-    // Replace within the formatted string
     let formattedString = format.replace(/MMMM|Do|YYYY|h|mm|ss|a|z|Z/g, (match) => replacements[match]);
 
     return formattedString;

--- a/src/lib/dateutil.ts
+++ b/src/lib/dateutil.ts
@@ -1,14 +1,23 @@
-export function formatDateTime(date, format): string {
+// export function formatDateTime(date, format, timezone = 'EST'): string {
+//import moment from 'moment-timezone';
+export function formatDateTime(date, format, timezone: string): string {
     if (!date) {
         date = new Date();
     }
-    const day = date.getUTCDate();
+    
+    // Create a date string with the timezone offset for parsing
+    let localDate = new Date(date);
+    
+    // Use methods based on timezone
+    const useUTC = timezone === 'UTC';
+    
+    const day = useUTC ? localDate.getUTCDate() : localDate.getDate();
     const ordinalSuffix = getOrdinalSuffix(day);
     const dayWithSuffix = `${day}${ordinalSuffix}`;
 
-    const hours = date.getUTCHours();
-    const minutes = date.getUTCMinutes();
-    const seconds = date.getUTCSeconds();
+    const hours = useUTC ? localDate.getUTCHours() : localDate.getHours();
+    const minutes = useUTC ? localDate.getUTCMinutes() : localDate.getMinutes();
+    const seconds = useUTC ? localDate.getUTCSeconds() : localDate.getSeconds();
     const ampm = hours >= 12 ? 'pm' : 'am';
     const formattedHours = hours % 12 || 12;
 
@@ -18,16 +27,34 @@ export function formatDateTime(date, format): string {
         "September", "October", "November", "December"
     ];
 
+    // Get month based on timezone
+    const month = useUTC ? localDate.getUTCMonth() : localDate.getMonth();
+    const year = useUTC ? localDate.getUTCFullYear() : localDate.getFullYear();
+    
+    // Get timezone abbreviation and offset
+    let tzAbbr = timezone;
+    let tzOffset;
+    
+    if (useUTC) {
+        tzOffset = '+00:00';
+    } else {
+        // For non-UTC timezones, calculate the offset
+        const offset = -localDate.getTimezoneOffset();
+        const offsetHours = Math.floor(Math.abs(offset) / 60);
+        const offsetMinutes = Math.abs(offset) % 60;
+        tzOffset = `${offset >= 0 ? '+' : '-'}${offsetHours.toString().padStart(2, '0')}:${offsetMinutes.toString().padStart(2, '0')}`;
+    }
+
     const replacements = {
-        'MMMM': monthNames[date.getUTCMonth()],
+        'MMMM': monthNames[month],
         'Do': dayWithSuffix,
-        'YYYY': date.getUTCFullYear(),
+        'YYYY': year,
         'h': formattedHours,
         'mm': minutes.toString().padStart(2, '0'),
         'ss': seconds.toString().padStart(2, '0'),
         'a': ampm,
-        'z': 'UTC',
-        'Z': '+00:00'
+        'z': tzAbbr,
+        'Z': tzOffset
     };
 
     return format.replace(/MMMM|Do|YYYY|h|mm|ss|a|z|Z/g, (match) => replacements[match]);

--- a/src/lib/dateutil.ts
+++ b/src/lib/dateutil.ts
@@ -1,77 +1,56 @@
-// export function formatDateTime(date, format, timezone = 'EST'): string {
-//import moment from 'moment-timezone';
-export function formatDateTime(date, format, timezone: string): string {
+import * as moment from 'moment-timezone';
+
+export function formatDateTime(date: Date | string | undefined, format: string, timezone: string = 'UTC'): string {
+    console.log(`Timezone received from CLI: ${timezone}`);
+
     if (!date) {
-        date = new Date();
-    }
-    
-    // Create a date string with the timezone offset for parsing
-    let localDate = new Date(date);
-    
-    // Use methods based on timezone
-    const useUTC = timezone === 'UTC';
-    
-    const day = useUTC ? localDate.getUTCDate() : localDate.getDate();
-    const ordinalSuffix = getOrdinalSuffix(day);
-    const dayWithSuffix = `${day}${ordinalSuffix}`;
-
-    const hours = useUTC ? localDate.getUTCHours() : localDate.getHours();
-    const minutes = useUTC ? localDate.getUTCMinutes() : localDate.getMinutes();
-    const seconds = useUTC ? localDate.getUTCSeconds() : localDate.getSeconds();
-    const ampm = hours >= 12 ? 'pm' : 'am';
-    const formattedHours = hours % 12 || 12;
-
-    const monthNames = [
-        "January", "February", "March", "April",
-        "May", "June", "July", "August",
-        "September", "October", "November", "December"
-    ];
-
-    // Get month based on timezone
-    const month = useUTC ? localDate.getUTCMonth() : localDate.getMonth();
-    const year = useUTC ? localDate.getUTCFullYear() : localDate.getFullYear();
-    
-    // Get timezone abbreviation and offset
-    let tzAbbr = timezone;
-    let tzOffset;
-    
-    if (useUTC) {
-        tzOffset = '+00:00';
-    } else {
-        // For non-UTC timezones, calculate the offset
-        const offset = -localDate.getTimezoneOffset();
-        const offsetHours = Math.floor(Math.abs(offset) / 60);
-        const offsetMinutes = Math.abs(offset) % 60;
-        tzOffset = `${offset >= 0 ? '+' : '-'}${offsetHours.toString().padStart(2, '0')}:${offsetMinutes.toString().padStart(2, '0')}`;
+        date = new Date(); // Use current date if none provided
     }
 
+    let zonedDate;
+    try {
+        let dateString: string;
+        if (date instanceof Date) {
+            // 1. Get the UTC parts of the date
+            const year = date.getUTCFullYear();
+            const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+            const day = String(date.getUTCDate()).padStart(2, '0');
+            const hours = String(date.getUTCHours()).padStart(2, '0');
+            const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+            const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+
+            // 2. Construct a UTC date string
+            dateString = `${year}-${month}-${day} ${hours}:${minutes}:${seconds} UTC`; // Explicit UTC
+
+        } else {
+            dateString = date; // Assume it's a string we can parse
+        }
+
+        // Ensure we parse the date in UTC and then convert to the desired timezone
+        zonedDate = moment.tz(dateString, 'YYYY-MM-DD HH:mm:ss UTC', 'UTC').tz(timezone);
+
+    } catch (error) {
+        console.warn(`Invalid timezone: ${timezone}, defaulting to UTC`);
+        zonedDate = moment.tz(date, 'UTC');
+    }
+
+    console.log(`Formatting date: ${zonedDate.format('YYYY-MM-DD HH:mm:ss')}, Timezone: ${timezone}, Output: ${zonedDate.format(format)}`);
+
+    // Construct replacements, ensuring timezone context
     const replacements = {
-        'MMMM': monthNames[month],
-        'Do': dayWithSuffix,
-        'YYYY': year,
-        'h': formattedHours,
-        'mm': minutes.toString().padStart(2, '0'),
-        'ss': seconds.toString().padStart(2, '0'),
-        'a': ampm,
-        'z': tzAbbr,
-        'Z': tzOffset
+        'MMMM': zonedDate.format('MMMM'),
+        'Do': zonedDate.format('Do'),
+        'YYYY': zonedDate.format('YYYY'),
+        'h': zonedDate.format('h'),
+        'mm': zonedDate.format('mm'),
+        'ss': zonedDate.format('ss'),
+        'a': zonedDate.format('a'),
+        'z': zonedDate.format('z'),
+        'Z': zonedDate.format('Z')
     };
 
-    return format.replace(/MMMM|Do|YYYY|h|mm|ss|a|z|Z/g, (match) => replacements[match]);
-}
+    // Replace within the formatted string
+    let formattedString = format.replace(/MMMM|Do|YYYY|h|mm|ss|a|z|Z/g, (match) => replacements[match]);
 
-function getOrdinalSuffix(day) {
-    if (day > 3 && day < 21) {
-        return 'th';
-    }
-    switch (day % 10) {
-        case 1:
-            return 'st';
-        case 2:
-            return 'nd';
-        case 3:
-            return 'rd';
-        default:
-            return 'th';
-    }
+    return formattedString;
 }

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -59,7 +59,7 @@ class SnykToHtml {
                     hbsTemplate: string,
                     summary: boolean,
                     reportCallback: (value: string) => void,
-                    timezone: string = 'UTC+00:00',): void {
+    timezone: string = 'UTC+00:00',): void {
     SnykToHtml
       .runAsync(dataSource, remediation, hbsTemplate, summary)
       .then(reportCallback)

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -124,10 +124,7 @@ class SnykToHtml {
   }
 
   private generateReport(report: string): string {
-    const currentDate = new Date();
-    const formattedDate = formatDateTime(currentDate, 'YYYY-MM-DD HH:mm:ss', this.timezone);
-    console.log(`Final report generated at ${formattedDate} with timezone: ${this.timezone}`);
-    return `Generated Report at ${formattedDate} with Timezone: ${this.timezone}\n${report}`;
+    return report;
   }
 }
 

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -385,6 +385,7 @@ async function readInputFromStdin(): Promise<string> {
 
 // handlebar helpers
 const timezone = this.timezone;
+
 const hh = {
   markdown: marked.parse,
   moment: function(date, format, timezone) {

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -58,7 +58,8 @@ class SnykToHtml {
                     remediation: boolean,
                     hbsTemplate: string,
                     summary: boolean,
-                    reportCallback: (value: string) => void): void {
+                    reportCallback: (value: string) => void,
+                    timezone: string = 'UTC+00:00',): void {
     SnykToHtml
       .runAsync(dataSource, remediation, hbsTemplate, summary)
       .then(reportCallback)
@@ -381,9 +382,12 @@ async function readInputFromStdin(): Promise<string> {
 }
 
 // handlebar helpers
+const timezone = this.timezone;
 const hh = {
   markdown: marked.parse,
-  moment: (date, format) => formatDateTime(date, format),
+  moment: function(date, format) {
+    return formatDateTime(date, format, timezone);
+  },
   count: data => data && data.length,
   dump: (data, spacer) => JSON.stringify(data, null, spacer || null),
   // block helpers


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Commits are squashed and tidy and are suitable to become release notes

### What this does

Currently the timezone is set to a default of UTC. Many users have asked for timezone support so that they can add one more relevant to their team.

This PR adds a -z/--timezone option using the --timezone America/Los_Angeles format and applies it to the timestamp on the HTML report.

The existing release uses the 'moment' library for setting the time, so the project has been updated to include 'moment-timezone'. We take a timezone as command line argument, pass it to dateutil.ts for formatting, and finally snyk-to-html.ts applies it to the report.

### Notes for the reviewer

It's been tested with Snyk Open Source, Snyk Code, and Snyk IaC. The current production release of snyk-to-html doesn't seem to generate reports for Snyk Container.

To test it, navigate into the project.
npm install
snyk test --json > results.json
node ./dist/index.js -o results-opensource.html -i results.json --timezone America/Los_Angeles
Open results-opensource.html

### More information

No known issues.

### Screenshots

<img width="1367" alt="Screenshot 2025-03-20 at 10 46 53 AM" src="https://github.com/user-attachments/assets/7d9cdf8d-92e3-4764-817f-f0b69a008035" />

