### PR TITLE
feat: remove use of JS for dataflow & fix analisys tabs

### DIFF
--- a/template/code/test-report.code-snip.hbs
+++ b/template/code/test-report.code-snip.hbs
@@ -1,11 +1,14 @@
 <div class="card card--vuln  disclosure--not-new severity--{{severitytext}}" data-snyk-test="{{severitytext}}">
+    <input type="radio" name="tab-view-{{@index}}" id="tab-dataflow-{{@index}}" value="dataflow" class="card__tab__radio" checked>
+    <input type="radio" name="tab-view-{{@index}}" id="tab-fix-{{@index}}" value="fix" class="card__tab__radio" >
+
     <header class="card__header">
         <div class="card__header__main">
             <div class="severity-icon severity-icon--{{severitytext}}"></div>
             <h2 class="card__title">{{ruleiddesc.shortDescription.text}}</h2>
             <div class="card__actions">
-                <span class="card__action card-dataflow is-selected" onclick="toggleCardView(event)">Data Flow</span>
-                <span class="card__action card-fix" onclick="toggleCardView(event)">Fix Analysis</span>
+                <label for="tab-dataflow-{{@index}}" class="card__action">Data Flow</label>
+                <label for="tab-fix-{{@index}}" class="card__action">Fix Analysis</label>
             </div>
         </div>
         <ul class="card__meta">

--- a/template/code/test-report.inline-css.hbs
+++ b/template/code/test-report.inline-css.hbs
@@ -284,15 +284,37 @@
 .scan-coverage { max-width: 400px; padding:0; margin:12px 0 0; font-size:14px; }
 .scan-coverage .type { display:inline-block; list-style-type: none; padding:3px; margin:0 0 0 10px; }
 
-.card { padding:0; border-width:4px 1px 1px; border-color:#d3d3d9; border-radius: 4px 4px 0 0 }
-.card.severity--low { border-top-color: #88879E; }
-.card.severity--medium { border-top-color: #D68000; }
-.card.severity--high { border-top-color: #CE5019; }
-.card.severity--critical { border-top-color: #AB1A1A; }
+.card.severity--low { --severity-color: #88879E; }
+.card.severity--medium { --severity-color: #D68000; }
+.card.severity--high { --severity-color: #CE5019; }
+.card.severity--critical { --severity-color: #AB1A1A; }
+.card {
+  padding:0;
+  border-width:4px 1px 1px;
+  border-color:#d3d3d9;
+  border-top-color: var(--severity-color);
+  border-radius: 4px 4px 0 0;
+}
 
-.card .fix-analysis { display:none }
-.card.show-fix .fix-analysis { display:block }
-.card.show-fix .dataflow { display:none }
+.card__tab__radio { display: none; pointer-events: none; }
+.dataflow, .fix-analysis { display: none; }
+
+.card input[id^="tab-dataflow"]:checked ~ .card__header .card__action[for^="tab-dataflow"] {
+  background-color: var(--severity-color);
+  color: #fff;
+  border-radius: 20px;
+}
+
+.card input[id^="tab-fix"]:checked ~ .card__header .card__action[for^="tab-fix"] {
+  background-color: #4b45a1;
+  color: #fff;
+  border-radius: 20px;
+}
+
+.card input[id^="tab-dataflow"]:checked ~ .card__section .dataflow,
+.card input[id^="tab-fix"]:checked ~ .card__section .fix-analysis {
+  display: block;
+}
 
 .card__header { padding:24px }
 .card__header__main { display:flex; }
@@ -305,10 +327,6 @@
 .card__actions { display:flex; padding:2px; border:1px solid #d3d3d9; border-radius:20px; background-color:#fff;  margin-left: auto; }
 .card__action { align-self: center; padding:5px 15px; font-size:14px; cursor: pointer; transition: all .2s; }
 .card__action:hover { color: #4b45a1; }
-.card__action.is-selected { background-color:#4b45a1; color:#fff; border-radius:20px; }
-.severity--high .card-dataflow.is-selected { background-color:#CE5019 ; }
-.severity--medium .card-dataflow.is-selected { background-color:#D68000 ; }
-.severity--low .card-dataflow.is-selected { background-color:#88879E ; }
 
 .card__section {padding:24px; border-top: 1px solid #d3d3d9}
 

--- a/template/code/test-report.inline-js.hbs
+++ b/template/code/test-report.inline-js.hbs
@@ -50,30 +50,4 @@
       targetPanes[0].classList.add('shown');
     }
   }
-
-// https://gomakethings.com/how-to-get-the-closest-parent-element-with-a-matching-selector-using-vanilla-javascript/
-  function getClosest(element, selector) {
-    for ( ; element && element !== document; element = element.parentNode ) {
-      if ( element.matches( selector ) ) return element;
-    }
-    return null;
-  }
-
-  function toggleCardView(event) {
-    var clickedButton = event.target;
-    var card = this.getClosest(clickedButton, '.card');
-    if (clickedButton.classList.contains('card-fix')){
-      if (clickedButton.classList.contains('is-selected')) 
-        return;
-      clickedButton.classList.add('is-selected');
-      clickedButton.previousElementSibling.classList.remove('is-selected');
-      card.classList.add('show-fix');
-    } else {
-      if (clickedButton.classList.contains('is-selected')) 
-        return;
-      clickedButton.classList.add('is-selected');
-      clickedButton.nextElementSibling.classList.remove('is-selected');
-      card.classList.remove('show-fix');
-    }
-  }
 </script>


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Commits are squashed and tidy and are suitable to become release notes

### What this does

Fix analysis is currently inaccessible in our Azure DevOps integration since the report uses JavaScript for switching between the dataflow and fix analysis tabs. This PR removes the need for JS by mimicking the behaviour by using two invisible radio buttons and some CSS styling.

### Notes for the reviewer

How does this work? The magic lies on the two radio buttons added. Even if the input elements have `display: none`, clicking on the labels still triggers an input event, making it perfect for switching the tabs between fix and dataflow. The trickier part is syncing the state from the input elements to the dataflow and fix analysis content.

The CSS queries I used could be made a bit more simpler and shorter if I had use the `:has` selector, but I was unsure if the [browser support numbers](https://caniuse.com/css-has) are enough for us to consider. So the following css selector was used:

```css
.card input[id^="tab-dataflow"]:checked ~ .card__header .card__action[for^="tab-dataflow"]{...}
```

It looks a bit scary, but it can be broken in 3 parts:
-> looks for a `card` element with an radio input that has the id prefix `tab-dataflow` and is checked
--> selects a sibling element (~ selector) with the `card__header` class
---> targets the `card__action` class element that has the property `for` with the prefix `tab-dataflow`

TLDR: targets the label for the radio button if it's checked. Can be used identically for the fix-analysis element

### More information

- [CLI-641](https://snyksec.atlassian.net/browse/CLI-641)

[CLI-641]: https://snyksec.atlassian.net/browse/CLI-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ