### PR TITLE
feat: replacing marked with showdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "handlebars": "^4.7.8",
     "lodash.isempty": "^4.4.0",
     "lodash.orderby": "^4.6.0",
-    "marked": "^15.0.12"
+    "showdown": "^2.1.0"
   },
   "bin": {
     "snyk-to-html": "dist/index.js"

--- a/test/__snapshots__/snyk-from-commandline.spec.ts.snap
+++ b/test/__snapshots__/snyk-from-commandline.spec.ts.snap
@@ -841,27 +841,27 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
               
                     <hr/>
                     <!-- Overview -->
-                    <h2>Overview</h2>
+                    <h2 id="overview">Overview</h2>
               <p><a href="https://www.npmjs.com/package/tunnel-agent"><code>tunnel-agent</code></a> is HTTP proxy tunneling agent. Affected versions of the package are vulnerable to Uninitialized Memory Exposure. </p>
               <p>A possible memory disclosure vulnerability exists when a value of type <code>number</code> is used to set the <em>proxy.auth</em> option of a request <code>request</code> and results in a possible uninitialized memory exposures in the request body.</p>
               <p>This is a result of unobstructed use of the <code>Buffer</code> constructor, whose <a href="https://snyk.io/blog/exploiting-buffer/">insecure default constructor increases the odds of memory leakage</a>.</p>
-              <h2>Details</h2>
-              <p>Constructing a <code>Buffer</code> class with integer <code>N</code> creates a <code>Buffer</code> of length <code>N</code> with raw (not &quot;zero-ed&quot;) memory.</p>
-              <p>In the following example, the first call would allocate 100 bytes of memory, while the second example will allocate the memory needed for the string &quot;100&quot;:</p>
-              <pre><code class="language-js">// uninitialized Buffer of length 100
+              <h2 id="details">Details</h2>
+              <p>Constructing a <code>Buffer</code> class with integer <code>N</code> creates a <code>Buffer</code> of length <code>N</code> with raw (not "zero-ed") memory.</p>
+              <p>In the following example, the first call would allocate 100 bytes of memory, while the second example will allocate the memory needed for the string "100":</p>
+              <pre><code class="js language-js">// uninitialized Buffer of length 100
               x = new Buffer(100);
-              // initialized Buffer with value of &#39;100&#39;
-              x = new Buffer(&#39;100&#39;);
+              // initialized Buffer with value of '100'
+              x = new Buffer('100');
               </code></pre>
-              <p><code>tunnel-agent</code>&#39;s <code>request</code> construction uses the default <code>Buffer</code> constructor as-is, making it easy to append uninitialized memory to an existing list. If the value of the buffer list is exposed to users, it may expose raw server side memory, potentially holding secrets, private data and code. This is a similar vulnerability to the infamous <a href="http://heartbleed.com/"><code>Heartbleed</code></a> flaw in OpenSSL.</p>
-              <h4>Proof of concept by ChALkeR</h4>
-              <pre><code class="language-js">require(&#39;request&#39;)({
-                method: &#39;GET&#39;,
-                uri: &#39;http://www.example.com&#39;,
+              <p><code>tunnel-agent</code>'s <code>request</code> construction uses the default <code>Buffer</code> constructor as-is, making it easy to append uninitialized memory to an existing list. If the value of the buffer list is exposed to users, it may expose raw server side memory, potentially holding secrets, private data and code. This is a similar vulnerability to the infamous <a href="http://heartbleed.com/"><code>Heartbleed</code></a> flaw in OpenSSL.</p>
+              <h4 id="proofofconceptbychalker">Proof of concept by ChALkeR</h4>
+              <pre><code class="js language-js">require('request')({
+                method: 'GET',
+                uri: 'http://www.example.com',
                 tunnel: true,
                 proxy:{
-                    protocol: &#39;http:&#39;,
-                    host:&quot;127.0.0.1&quot;,
+                    protocol: 'http:',
+                    host:"127.0.0.1",
                     port:8080,
                     auth:80
                 }
@@ -869,15 +869,14 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
               </code></pre>
               <p>You can read more about the insecure <code>Buffer</code> behavior <a href="https://snyk.io/blog/exploiting-buffer/">on our blog</a>.</p>
               <p>Similar vulnerabilities were discovered in <a href="https://snyk.io/vuln/npm:request:20160119">request</a>, <a href="https://snyk.io/vuln/npm:mongoose:20160116">mongoose</a>, <a href="https://snyk.io/vuln/npm:ws:20160104">ws</a> and <a href="https://snyk.io/vuln/npm:sequelize:20160115">sequelize</a>.</p>
-              <h2>Remediation</h2>
+              <h2 id="remediation">Remediation</h2>
               <p>Upgrade <code>tunnel-agent</code> to version 0.6.0 or higher.
               <strong>Note</strong> This is vulnerable only for Node &lt;=4</p>
-              <h2>References</h2>
+              <h2 id="references">References</h2>
               <ul>
               <li><a href="https://github.com/request/tunnel-agent/commit/9ca95ec7219daface8a6fc2674000653de0922c0">GitHub Commit</a></li>
               <li><a href="https://gist.github.com/ChALkeR/fd6b2c445834244e7d440a043f9d2ff4">PoC by ChALkeR</a></li>
               </ul>
-              
                     <hr/>
               
                   <div class="cta card__cta">
@@ -941,27 +940,25 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
               
                     <hr/>
                     <!-- Overview -->
-                    <h2>Overview</h2>
+                    <h2 id="overview">Overview</h2>
               <p><a href="https://www.npmjs.com/package/minimist">minimist</a> is a parse argument options module.</p>
               <p>Affected versions of this package are vulnerable to Prototype Pollution.
               The library could be tricked into adding or modifying properties of <code>Object.prototype</code> using a <code>constructor</code> or <code>__proto__</code> payload.</p>
-              <h2>PoC by Snyk</h2>
-              <pre><code>require(&#39;minimist&#39;)(&#39;--__proto__.injected0 value0&#39;.split(&#39; &#39;));
-              console.log(({}).injected0 === &#39;value0&#39;); // true
+              <h2 id="pocbysnyk">PoC by Snyk</h2>
+              <pre><code>require('minimist')('--__proto__.injected0 value0'.split(' '));
+              console.log(({}).injected0 === 'value0'); // true
               
-              require(&#39;minimist&#39;)(&#39;--constructor.prototype.injected1 value1&#39;.split(&#39; &#39;));
-              console.log(({}).injected1 === &#39;value1&#39;); // true
+              require('minimist')('--constructor.prototype.injected1 value1'.split(' '));
+              console.log(({}).injected1 === 'value1'); // true
               </code></pre>
-              <h2>Details</h2>
+              <h2 id="details">Details</h2>
               <p>Prototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as <code>_proto_</code>, <code>constructor</code> and <code>prototype</code>. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the <code>Object.prototype</code> are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.</p>
               <p>There are two main ways in which the pollution of prototypes occurs:</p>
               <ul>
-              <li><p>Unsafe <code>Object</code> recursive merge</p>
-              </li>
-              <li><p>Property definition by path</p>
-              </li>
+              <li><p>Unsafe <code>Object</code> recursive merge</p></li>
+              <li><p>Property definition by path</p></li>
               </ul>
-              <h3>Unsafe Object recursive merge</h3>
+              <h3 id="unsafeobjectrecursivemerge">Unsafe Object recursive merge</h3>
               <p>The logic of a vulnerable recursive merge function follows the following high-level model:</p>
               <pre><code>merge (target, source)
               
@@ -975,77 +972,45 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
               
                     target[property] = source[property]
               </code></pre>
-              <br>  
-              
+              <p><br>  </p>
               <p>When the source object contains a property named <code>_proto_</code> defined with <code>Object.defineProperty()</code> , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of <code>Object</code> and the source of <code>Object</code> as defined by the attacker. Properties are then copied on the <code>Object</code> prototype.</p>
               <p>Clone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: <code>merge({},source)</code>.</p>
               <p><code>lodash</code> and <code>Hoek</code> are examples of libraries susceptible to recursive merge attacks.</p>
-              <h3>Property definition by path</h3>
+              <h3 id="propertydefinitionbypath">Property definition by path</h3>
               <p>There are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: <code>theFunction(object, path, value)</code></p>
               <p>If the attacker can control the value of “path”, they can set this value to <code>_proto_.myValue</code>. <code>myValue</code> is then assigned to the prototype of the class of the object.</p>
-              <h2>Types of attacks</h2>
+              <h2 id="typesofattacks">Types of attacks</h2>
               <p>There are a few methods by which Prototype Pollution can be manipulated:</p>
-              <table>
-              <thead>
-              <tr>
-              <th>Type</th>
-              <th>Origin</th>
-              <th>Short description</th>
-              </tr>
-              </thead>
-              <tbody><tr>
-              <td><strong>Denial of service (DoS)</strong></td>
-              <td>Client</td>
-              <td>This is the most likely attack. <br>DoS occurs when <code>Object</code> holds generic functions that are implicitly called for various operations (for example, <code>toString</code> and <code>valueOf</code>). <br> The attacker pollutes <code>Object.prototype.someattr</code> and alters its state to an unexpected value such as <code>Int</code> or <code>Object</code>. In this case, the code fails and is likely to cause a denial of service.  <br><strong>For example:</strong> if an attacker pollutes <code>Object.prototype.toString</code> by defining it as an integer, if the codebase at any point was reliant on <code>someobject.toString()</code> it would fail.</td>
-              </tr>
-              <tr>
-              <td><strong>Remote Code Execution</strong></td>
-              <td>Client</td>
-              <td>Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br><strong>For example:</strong> <code>eval(someobject.someattr)</code>. In this case, if the attacker pollutes <code>Object.prototype.someattr</code> they are likely to be able to leverage this in order to execute code.</td>
-              </tr>
-              <tr>
-              <td><strong>Property Injection</strong></td>
-              <td>Client</td>
-              <td>The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  <strong>For example:</strong> if a codebase checks privileges for <code>someuser.isAdmin</code>, then when the attacker pollutes <code>Object.prototype.isAdmin</code> and sets it to equal <code>true</code>, they can then achieve admin privileges.</td>
-              </tr>
-              </tbody></table>
-              <h2>Affected environments</h2>
+              <p>| Type |Origin  |Short description |
+              |--|--|--|
+              | <strong>Denial of service (DoS)</strong>|Client  |This is the most likely attack. <br>DoS occurs when <code>Object</code> holds generic functions that are implicitly called for various operations (for example, <code>toString</code> and <code>valueOf</code>). <br> The attacker pollutes <code>Object.prototype.someattr</code> and alters its state to an unexpected value such as <code>Int</code> or <code>Object</code>. In this case, the code fails and is likely to cause a denial of service.  <br><strong>For example:</strong> if an attacker pollutes <code>Object.prototype.toString</code> by defining it as an integer, if the codebase at any point was reliant on <code>someobject.toString()</code> it would fail. |
+               |<strong>Remote Code Execution</strong>|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br><strong>For example:</strong> <code>eval(someobject.someattr)</code>. In this case, if the attacker pollutes <code>Object.prototype.someattr</code> they are likely to be able to leverage this in order to execute code.|
+              |<strong>Property Injection</strong>|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  <strong>For example:</strong> if a codebase checks privileges for <code>someuser.isAdmin</code>, then when the attacker pollutes <code>Object.prototype.isAdmin</code> and sets it to equal <code>true</code>, they can then achieve admin privileges.|</p>
+              <h2 id="affectedenvironments">Affected environments</h2>
               <p>The following environments are susceptible to a Prototype Pollution attack:</p>
               <ul>
-              <li><p>Application server</p>
-              </li>
-              <li><p>Web server</p>
-              </li>
+              <li><p>Application server</p></li>
+              <li><p>Web server</p></li>
               </ul>
-              <h2>How to prevent</h2>
+              <h2 id="howtoprevent">How to prevent</h2>
               <ol>
-              <li><p>Freeze the prototype— use <code>Object.freeze (Object.prototype)</code>.</p>
-              </li>
-              <li><p>Require schema validation of JSON input.</p>
-              </li>
-              <li><p>Avoid using unsafe recursive merge functions.</p>
-              </li>
-              <li><p>Consider using objects without prototypes (for example, <code>Object.create(null)</code>), breaking the prototype chain and preventing pollution.</p>
-              </li>
-              <li><p>As a best practice use <code>Map</code> instead of <code>Object</code>.</p>
-              </li>
+              <li><p>Freeze the prototype— use <code>Object.freeze (Object.prototype)</code>.</p></li>
+              <li><p>Require schema validation of JSON input.</p></li>
+              <li><p>Avoid using unsafe recursive merge functions.</p></li>
+              <li><p>Consider using objects without prototypes (for example, <code>Object.create(null)</code>), breaking the prototype chain and preventing pollution.</p></li>
+              <li><p>As a best practice use <code>Map</code> instead of <code>Object</code>.</p></li>
               </ol>
-              <h3>For more information on this vulnerability type:</h3>
+              <h3 id="formoreinformationonthisvulnerabilitytype">For more information on this vulnerability type:</h3>
               <p><a href="https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf">Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018</a></p>
-              <h2>Remediation</h2>
+              <h2 id="remediation">Remediation</h2>
               <p>Upgrade <code>minimist</code> to version 0.2.1, 1.2.3 or higher.</p>
-              <h2>References</h2>
+              <h2 id="references">References</h2>
               <ul>
-              <li><p><a href="https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a">Command Injection PoC</a></p>
-              </li>
-              <li><p><a href="https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94">GitHub Fix Commit #1</a></p>
-              </li>
-              <li><p><a href="https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab">GitHub Fix Commit #2</a></p>
-              </li>
-              <li><p><a href="https://snyk.io/blog/prototype-pollution-minimist/">Snyk Research Blog</a></p>
-              </li>
+              <li><p><a href="https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a">Command Injection PoC</a></p></li>
+              <li><p><a href="https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94">GitHub Fix Commit #1</a></p></li>
+              <li><p><a href="https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab">GitHub Fix Commit #2</a></p></li>
+              <li><p><a href="https://snyk.io/blog/prototype-pollution-minimist/">Snyk Research Blog</a></p></li>
               </ul>
-              
                     <hr/>
               
                   <div class="cta card__cta">
@@ -1109,25 +1074,23 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
               
                     <hr/>
                     <!-- Overview -->
-                    <h2>Overview</h2>
+                    <h2 id="overview">Overview</h2>
               <p><a href="https://www.npmjs.com/package/lodash">lodash</a> is a modern JavaScript utility library delivering modularity, performance, &amp; extras.</p>
               <p>Affected versions of this package are vulnerable to Prototype Pollution.
               The function <code>zipObjectDeep</code> can be tricked into adding or modifying properties of the Object prototype. These properties will be present on all objects.</p>
-              <h2>PoC</h2>
-              <pre><code>const _ = require(&#39;lodash&#39;);
-              _.zipObjectDeep([&#39;__proto__.z&#39;],[123])
+              <h2 id="poc">PoC</h2>
+              <pre><code>const _ = require('lodash');
+              _.zipObjectDeep(['__proto__.z'],[123])
               console.log(z) // 123
               </code></pre>
-              <h2>Details</h2>
+              <h2 id="details">Details</h2>
               <p>Prototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as <code>_proto_</code>, <code>constructor</code> and <code>prototype</code>. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the <code>Object.prototype</code> are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.</p>
               <p>There are two main ways in which the pollution of prototypes occurs:</p>
               <ul>
-              <li><p>Unsafe <code>Object</code> recursive merge</p>
-              </li>
-              <li><p>Property definition by path</p>
-              </li>
+              <li><p>Unsafe <code>Object</code> recursive merge</p></li>
+              <li><p>Property definition by path</p></li>
               </ul>
-              <h3>Unsafe Object recursive merge</h3>
+              <h3 id="unsafeobjectrecursivemerge">Unsafe Object recursive merge</h3>
               <p>The logic of a vulnerable recursive merge function follows the following high-level model:</p>
               <pre><code>merge (target, source)
               
@@ -1141,70 +1104,42 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
               
                     target[property] = source[property]
               </code></pre>
-              <br>  
-              
+              <p><br>  </p>
               <p>When the source object contains a property named <code>_proto_</code> defined with <code>Object.defineProperty()</code> , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of <code>Object</code> and the source of <code>Object</code> as defined by the attacker. Properties are then copied on the <code>Object</code> prototype.</p>
               <p>Clone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: <code>merge({},source)</code>.</p>
               <p><code>lodash</code> and <code>Hoek</code> are examples of libraries susceptible to recursive merge attacks.</p>
-              <h3>Property definition by path</h3>
+              <h3 id="propertydefinitionbypath">Property definition by path</h3>
               <p>There are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: <code>theFunction(object, path, value)</code></p>
               <p>If the attacker can control the value of “path”, they can set this value to <code>_proto_.myValue</code>. <code>myValue</code> is then assigned to the prototype of the class of the object.</p>
-              <h2>Types of attacks</h2>
+              <h2 id="typesofattacks">Types of attacks</h2>
               <p>There are a few methods by which Prototype Pollution can be manipulated:</p>
-              <table>
-              <thead>
-              <tr>
-              <th>Type</th>
-              <th>Origin</th>
-              <th>Short description</th>
-              </tr>
-              </thead>
-              <tbody><tr>
-              <td><strong>Denial of service (DoS)</strong></td>
-              <td>Client</td>
-              <td>This is the most likely attack. <br>DoS occurs when <code>Object</code> holds generic functions that are implicitly called for various operations (for example, <code>toString</code> and <code>valueOf</code>). <br> The attacker pollutes <code>Object.prototype.someattr</code> and alters its state to an unexpected value such as <code>Int</code> or <code>Object</code>. In this case, the code fails and is likely to cause a denial of service.  <br><strong>For example:</strong> if an attacker pollutes <code>Object.prototype.toString</code> by defining it as an integer, if the codebase at any point was reliant on <code>someobject.toString()</code> it would fail.</td>
-              </tr>
-              <tr>
-              <td><strong>Remote Code Execution</strong></td>
-              <td>Client</td>
-              <td>Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br><strong>For example:</strong> <code>eval(someobject.someattr)</code>. In this case, if the attacker pollutes <code>Object.prototype.someattr</code> they are likely to be able to leverage this in order to execute code.</td>
-              </tr>
-              <tr>
-              <td><strong>Property Injection</strong></td>
-              <td>Client</td>
-              <td>The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  <strong>For example:</strong> if a codebase checks privileges for <code>someuser.isAdmin</code>, then when the attacker pollutes <code>Object.prototype.isAdmin</code> and sets it to equal <code>true</code>, they can then achieve admin privileges.</td>
-              </tr>
-              </tbody></table>
-              <h2>Affected environments</h2>
+              <p>| Type |Origin  |Short description |
+              |--|--|--|
+              | <strong>Denial of service (DoS)</strong>|Client  |This is the most likely attack. <br>DoS occurs when <code>Object</code> holds generic functions that are implicitly called for various operations (for example, <code>toString</code> and <code>valueOf</code>). <br> The attacker pollutes <code>Object.prototype.someattr</code> and alters its state to an unexpected value such as <code>Int</code> or <code>Object</code>. In this case, the code fails and is likely to cause a denial of service.  <br><strong>For example:</strong> if an attacker pollutes <code>Object.prototype.toString</code> by defining it as an integer, if the codebase at any point was reliant on <code>someobject.toString()</code> it would fail. |
+               |<strong>Remote Code Execution</strong>|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br><strong>For example:</strong> <code>eval(someobject.someattr)</code>. In this case, if the attacker pollutes <code>Object.prototype.someattr</code> they are likely to be able to leverage this in order to execute code.|
+              |<strong>Property Injection</strong>|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  <strong>For example:</strong> if a codebase checks privileges for <code>someuser.isAdmin</code>, then when the attacker pollutes <code>Object.prototype.isAdmin</code> and sets it to equal <code>true</code>, they can then achieve admin privileges.|</p>
+              <h2 id="affectedenvironments">Affected environments</h2>
               <p>The following environments are susceptible to a Prototype Pollution attack:</p>
               <ul>
-              <li><p>Application server</p>
-              </li>
-              <li><p>Web server</p>
-              </li>
+              <li><p>Application server</p></li>
+              <li><p>Web server</p></li>
               </ul>
-              <h2>How to prevent</h2>
+              <h2 id="howtoprevent">How to prevent</h2>
               <ol>
-              <li><p>Freeze the prototype— use <code>Object.freeze (Object.prototype)</code>.</p>
-              </li>
-              <li><p>Require schema validation of JSON input.</p>
-              </li>
-              <li><p>Avoid using unsafe recursive merge functions.</p>
-              </li>
-              <li><p>Consider using objects without prototypes (for example, <code>Object.create(null)</code>), breaking the prototype chain and preventing pollution.</p>
-              </li>
-              <li><p>As a best practice use <code>Map</code> instead of <code>Object</code>.</p>
-              </li>
+              <li><p>Freeze the prototype— use <code>Object.freeze (Object.prototype)</code>.</p></li>
+              <li><p>Require schema validation of JSON input.</p></li>
+              <li><p>Avoid using unsafe recursive merge functions.</p></li>
+              <li><p>Consider using objects without prototypes (for example, <code>Object.create(null)</code>), breaking the prototype chain and preventing pollution.</p></li>
+              <li><p>As a best practice use <code>Map</code> instead of <code>Object</code>.</p></li>
               </ol>
-              <h3>For more information on this vulnerability type:</h3>
+              <h3 id="formoreinformationonthisvulnerabilitytype">For more information on this vulnerability type:</h3>
               <p><a href="https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf">Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018</a></p>
-              <h2>Remediation</h2>
+              <h2 id="remediation">Remediation</h2>
               <p>There is no fixed version for <code>lodash</code>.</p>
-              <h2>References</h2>
+              <h2 id="references">References</h2>
               <ul>
               <li><a href="https://hackerone.com/reports/712065">HackerOne Report</a></li>
               </ul>
-              
                     <hr/>
               
                   <div class="cta card__cta">
@@ -1319,29 +1254,27 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
               
                     <hr/>
                     <!-- Overview -->
-                    <h2>Overview</h2>
+                    <h2 id="overview">Overview</h2>
               <p><a href="https://github.com/hapijs/hoek">hoek</a> is a Utility methods for the hapi ecosystem.</p>
               <p>Affected versions of this package are vulnerable to Prototype Pollution.
               The utilities function allow modification of the <code>Object</code> prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  </p>
-              <h2>PoC by Olivier Arteau (HoLyVieR)</h2>
-              <pre><code class="language-js">var Hoek = require(&#39;hoek&#39;);
-              var malicious_payload = &#39;{&quot;__proto__&quot;:{&quot;oops&quot;:&quot;It works !&quot;}}&#39;;
+              <h2 id="pocbyolivierarteauholyvier">PoC by Olivier Arteau (HoLyVieR)</h2>
+              <pre><code class="js language-js">var Hoek = require('hoek');
+              var malicious_payload = '{"__proto__":{"oops":"It works !"}}';
               
               var a = {};
-              console.log(&quot;Before : &quot; + a.oops);
+              console.log("Before : " + a.oops);
               Hoek.merge({}, JSON.parse(malicious_payload));
-              console.log(&quot;After : &quot; + a.oops);
+              console.log("After : " + a.oops);
               </code></pre>
-              <h2>Details</h2>
+              <h2 id="details">Details</h2>
               <p>Prototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as <code>_proto_</code>, <code>constructor</code> and <code>prototype</code>. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the <code>Object.prototype</code> are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.</p>
               <p>There are two main ways in which the pollution of prototypes occurs:</p>
               <ul>
-              <li><p>Unsafe <code>Object</code> recursive merge</p>
-              </li>
-              <li><p>Property definition by path</p>
-              </li>
+              <li><p>Unsafe <code>Object</code> recursive merge</p></li>
+              <li><p>Property definition by path</p></li>
               </ul>
-              <h3>Unsafe Object recursive merge</h3>
+              <h3 id="unsafeobjectrecursivemerge">Unsafe Object recursive merge</h3>
               <p>The logic of a vulnerable recursive merge function follows the following high-level model:</p>
               <pre><code>merge (target, source)
               
@@ -1355,81 +1288,47 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
               
                     target[property] = source[property]
               </code></pre>
-              <br>  
-              
+              <p><br>  </p>
               <p>When the source object contains a property named <code>_proto_</code> defined with <code>Object.defineProperty()</code> , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of <code>Object</code> and the source of <code>Object</code> as defined by the attacker. Properties are then copied on the <code>Object</code> prototype.</p>
               <p>Clone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: <code>merge({},source)</code>.</p>
               <p><code>lodash</code> and <code>Hoek</code> are examples of libraries susceptible to recursive merge attacks.</p>
-              <h3>Property definition by path</h3>
+              <h3 id="propertydefinitionbypath">Property definition by path</h3>
               <p>There are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: <code>theFunction(object, path, value)</code></p>
               <p>If the attacker can control the value of “path”, they can set this value to <code>_proto_.myValue</code>. <code>myValue</code> is then assigned to the prototype of the class of the object.</p>
-              <h2>Types of attacks</h2>
+              <h2 id="typesofattacks">Types of attacks</h2>
               <p>There are a few methods by which Prototype Pollution can be manipulated:</p>
-              <table>
-              <thead>
-              <tr>
-              <th>Type</th>
-              <th>Origin</th>
-              <th>Short description</th>
-              </tr>
-              </thead>
-              <tbody><tr>
-              <td><strong>Denial of service (DoS)</strong></td>
-              <td>Client</td>
-              <td>This is the most likely attack. <br>DoS occurs when <code>Object</code> holds generic functions that are implicitly called for various operations (for example, <code>toString</code> and <code>valueOf</code>). <br> The attacker pollutes <code>Object.prototype.someattr</code> and alters its state to an unexpected value such as <code>Int</code> or <code>Object</code>. In this case, the code fails and is likely to cause a denial of service.  <br><strong>For example:</strong> if an attacker pollutes <code>Object.prototype.toString</code> by defining it as an integer, if the codebase at any point was reliant on <code>someobject.toString()</code> it would fail.</td>
-              </tr>
-              <tr>
-              <td><strong>Remote Code Execution</strong></td>
-              <td>Client</td>
-              <td>Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br><strong>For example:</strong> <code>eval(someobject.someattr)</code>. In this case, if the attacker pollutes <code>Object.prototype.someattr</code> they are likely to be able to leverage this in order to execute code.</td>
-              </tr>
-              <tr>
-              <td><strong>Property Injection</strong></td>
-              <td>Client</td>
-              <td>The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  <strong>For example:</strong> if a codebase checks privileges for <code>someuser.isAdmin</code>, then when the attacker pollutes <code>Object.prototype.isAdmin</code> and sets it to equal <code>true</code>, they can then achieve admin privileges.</td>
-              </tr>
-              </tbody></table>
-              <h2>Affected environments</h2>
+              <p>| Type |Origin  |Short description |
+              |--|--|--|
+              | <strong>Denial of service (DoS)</strong>|Client  |This is the most likely attack. <br>DoS occurs when <code>Object</code> holds generic functions that are implicitly called for various operations (for example, <code>toString</code> and <code>valueOf</code>). <br> The attacker pollutes <code>Object.prototype.someattr</code> and alters its state to an unexpected value such as <code>Int</code> or <code>Object</code>. In this case, the code fails and is likely to cause a denial of service.  <br><strong>For example:</strong> if an attacker pollutes <code>Object.prototype.toString</code> by defining it as an integer, if the codebase at any point was reliant on <code>someobject.toString()</code> it would fail. |
+               |<strong>Remote Code Execution</strong>|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br><strong>For example:</strong> <code>eval(someobject.someattr)</code>. In this case, if the attacker pollutes <code>Object.prototype.someattr</code> they are likely to be able to leverage this in order to execute code.|
+              |<strong>Property Injection</strong>|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  <strong>For example:</strong> if a codebase checks privileges for <code>someuser.isAdmin</code>, then when the attacker pollutes <code>Object.prototype.isAdmin</code> and sets it to equal <code>true</code>, they can then achieve admin privileges.|</p>
+              <h2 id="affectedenvironments">Affected environments</h2>
               <p>The following environments are susceptible to a Prototype Pollution attack:</p>
               <ul>
-              <li><p>Application server</p>
-              </li>
-              <li><p>Web server</p>
-              </li>
+              <li><p>Application server</p></li>
+              <li><p>Web server</p></li>
               </ul>
-              <h2>How to prevent</h2>
+              <h2 id="howtoprevent">How to prevent</h2>
               <ol>
-              <li><p>Freeze the prototype— use <code>Object.freeze (Object.prototype)</code>.</p>
-              </li>
-              <li><p>Require schema validation of JSON input.</p>
-              </li>
-              <li><p>Avoid using unsafe recursive merge functions.</p>
-              </li>
-              <li><p>Consider using objects without prototypes (for example, <code>Object.create(null)</code>), breaking the prototype chain and preventing pollution.</p>
-              </li>
-              <li><p>As a best practice use <code>Map</code> instead of <code>Object</code>.</p>
-              </li>
+              <li><p>Freeze the prototype— use <code>Object.freeze (Object.prototype)</code>.</p></li>
+              <li><p>Require schema validation of JSON input.</p></li>
+              <li><p>Avoid using unsafe recursive merge functions.</p></li>
+              <li><p>Consider using objects without prototypes (for example, <code>Object.create(null)</code>), breaking the prototype chain and preventing pollution.</p></li>
+              <li><p>As a best practice use <code>Map</code> instead of <code>Object</code>.</p></li>
               </ol>
-              <h3>For more information on this vulnerability type:</h3>
+              <h3 id="formoreinformationonthisvulnerabilitytype">For more information on this vulnerability type:</h3>
               <p><a href="https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf">Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018</a></p>
-              <h2>Remediation</h2>
+              <h2 id="remediation">Remediation</h2>
               <p>Upgrade <code>hoek</code> to version 4.2.1, 5.0.3 or higher.</p>
-              <h2>References</h2>
+              <h2 id="references">References</h2>
               <ul>
-              <li><p><a href="https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee">GitHub Commit</a></p>
-              </li>
-              <li><p><a href="https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df">GitHub Commit</a></p>
-              </li>
-              <li><p><a href="https://github.com/hapijs/hoek/issues/230">GitHub Issue</a></p>
-              </li>
-              <li><p><a href="https://github.com/hapijs/hoek/pull/227">GitHub PR</a></p>
-              </li>
-              <li><p><a href="https://hackerone.com/reports/310439">HackerOne Report</a></p>
-              </li>
-              <li><p><a href="http://npmjs.com/advisories/566">NPM Security Advisory</a></p>
-              </li>
+              <li><p><a href="https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee">GitHub Commit</a></p></li>
+              <li><p><a href="https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df">GitHub Commit</a></p></li>
+              <li><p><a href="https://github.com/hapijs/hoek/issues/230">GitHub Issue</a></p></li>
+              <li><p><a href="https://github.com/hapijs/hoek/pull/227">GitHub PR</a></p></li>
+              <li><p><a href="https://hackerone.com/reports/310439">HackerOne Report</a></p></li>
+              <li><p><a href="http://npmjs.com/advisories/566">NPM Security Advisory</a></p></li>
               </ul>
-              
                     <hr/>
               
                   <div class="cta card__cta">
@@ -1489,17 +1388,17 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
               
                     <hr/>
                     <!-- Overview -->
-                    <h2>Overview</h2>
+                    <h2 id="overview">Overview</h2>
               <p><a href="https://www.npmjs.com/package/ms"><code>ms</code></a> is a tiny millisecond conversion utility.</p>
               <p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) due to an incomplete fix for previously reported vulnerability <a href="https://snyk.io/vuln/npm:ms:20151024">npm:ms:20151024</a>. The fix limited the length of accepted input string to 10,000 characters, and turned to be insufficient making it possible to block the event loop for 0.3 seconds (on a typical laptop) with a specially crafted string passed to <code>ms()</code> function.</p>
               <p><em>Proof of concept</em></p>
-              <pre><code class="language-js">ms = require(&#39;ms&#39;);
-              ms(&#39;1&#39;.repeat(9998) + &#39;Q&#39;) // Takes about ~0.3s
+              <pre><code class="js language-js">ms = require('ms');
+              ms('1'.repeat(9998) + 'Q') // Takes about ~0.3s
               </code></pre>
-              <p><strong>Note:</strong> Snyk&#39;s patch for this vulnerability limits input length to 100 characters. This new limit was deemed to be a breaking change by the author.
+              <p><strong>Note:</strong> Snyk's patch for this vulnerability limits input length to 100 characters. This new limit was deemed to be a breaking change by the author.
               Based on user feedback, we believe the risk of breakage is <em>very</em> low, while the value to your security is much greater, and therefore opted to still capture this change in a patch for earlier versions as well.  Whenever patching security issues, we always suggest to run tests on your code to validate that nothing has been broken.</p>
               <p>For more information on <code>Regular Expression Denial of Service (ReDoS)</code> attacks, go to our <a href="https://snyk.io/blog/redos-and-catastrophic-backtracking/">blog</a>.</p>
-              <h2>Disclosure Timeline</h2>
+              <h2 id="disclosuretimeline">Disclosure Timeline</h2>
               <ul>
               <li>Feb 9th, 2017 - Reported the issue to package owner.</li>
               <li>Feb 11th, 2017 - Issue acknowledged by package owner.</li>
@@ -1508,75 +1407,51 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
               <li>May 16th, 2017 - Issue fixed and version <code>2.0.0</code> released.</li>
               <li>May 21th, 2017 - Patches released for versions <code>&gt;=0.7.1, &lt;=1.0.0</code>.</li>
               </ul>
-              <h2>Details</h2>
+              <h2 id="details">Details</h2>
               <p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p>
-              <p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p>
+              <p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.</p>
               <p>Let’s take the following regular expression as an example:</p>
-              <pre><code class="language-js">regex = /A(B|C+)+D/
+              <pre><code class="js language-js">regex = /A(B|C+)+D/
               </code></pre>
               <p>This regular expression accomplishes the following:</p>
               <ul>
-              <li><code>A</code> The string must start with the letter &#39;A&#39;</li>
-              <li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li>
-              <li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li>
+              <li><code>A</code> The string must start with the letter 'A'</li>
+              <li><code>(B|C+)+</code> The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li>
+              <li><code>D</code> Finally, we ensure this section of the string ends with a 'D'</li>
               </ul>
               <p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p>
-              <p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p>
-              <pre><code class="language-bash">$ time node -e &#39;/A(B|C+)+D/.test(&quot;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&quot;)&#39;
+              <p>It most cases, it doesn't take very long for a regex engine to find a match:</p>
+              <pre><code class="bash language-bash">$ time node -e '/A(B|C+)+D/.test("ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD")'
               0.04s user 0.01s system 95% cpu 0.052 total
               
-              $ time node -e &#39;/A(B|C+)+D/.test(&quot;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&quot;)&#39;
+              $ time node -e '/A(B|C+)+D/.test("ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX")'
               1.79s user 0.02s system 99% cpu 1.812 total
               </code></pre>
               <p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p>
               <p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as <em>catastrophic backtracking</em>.</p>
-              <p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &quot;ACCCX&quot;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p>
+              <p>Let's look at how our expression runs into this problem, using a shorter string: "ACCCX". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:</p>
               <ol>
               <li>CCC</li>
               <li>CC+C</li>
               <li>C+CC</li>
               <li>C+C+C.</li>
               </ol>
-              <p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p>
+              <p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn't match.</p>
               <p>From there, the number of steps the engine must use to validate a string just continues to grow.</p>
-              <table>
-              <thead>
-              <tr>
-              <th>String</th>
-              <th align="right">Number of C&#39;s</th>
-              <th align="right">Number of steps</th>
-              </tr>
-              </thead>
-              <tbody><tr>
-              <td>ACCCX</td>
-              <td align="right">3</td>
-              <td align="right">38</td>
-              </tr>
-              <tr>
-              <td>ACCCCX</td>
-              <td align="right">4</td>
-              <td align="right">71</td>
-              </tr>
-              <tr>
-              <td>ACCCCCX</td>
-              <td align="right">5</td>
-              <td align="right">136</td>
-              </tr>
-              <tr>
-              <td>ACCCCCCCCCCCCCCX</td>
-              <td align="right">14</td>
-              <td align="right">65,553</td>
-              </tr>
-              </tbody></table>
-              <p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p>
-              <h2>Remediation</h2>
+              <p>| String | Number of C's | Number of steps |
+              | -------|-------------:| -----:|
+              | ACCCX | 3 | 38
+              | ACCCCX | 4 | 71
+              | ACCCCCX | 5 | 136
+              | ACCCCCCCCCCCCCCX | 14 | 65,553</p>
+              <p>By the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p>
+              <h2 id="remediation">Remediation</h2>
               <p>Upgrade <code>ms</code> to version 2.0.0 or higher.</p>
-              <h2>References</h2>
+              <h2 id="references">References</h2>
               <ul>
               <li><a href="https://github.com/zeit/ms/pull/89">GitHub PR</a></li>
               <li><a href="https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef">GitHub Commit</a></li>
               </ul>
-              
                     <hr/>
               
                   <div class="cta card__cta">
@@ -2168,15 +2043,14 @@ exports[`test calling snyk-to-html from command line handles the -s argument cor
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>tunnel-agent</code> to version 0.6.0 or higher.
         <strong>Note</strong> This is vulnerable only for Node &lt;=4</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/request/tunnel-agent/commit/9ca95ec7219daface8a6fc2674000653de0922c0">GitHub Commit</a></li>
         <li><a href="https://gist.github.com/ChALkeR/fd6b2c445834244e7d440a043f9d2ff4">PoC by ChALkeR</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:tunnel-agent:20170305">More about this vulnerability</a></p>
@@ -2215,20 +2089,15 @@ exports[`test calling snyk-to-html from command line handles the -s argument cor
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>minimist</code> to version 0.2.1, 1.2.3 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
-        <li><p><a href="https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a">Command Injection PoC</a></p>
-        </li>
-        <li><p><a href="https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94">GitHub Fix Commit #1</a></p>
-        </li>
-        <li><p><a href="https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab">GitHub Fix Commit #2</a></p>
-        </li>
-        <li><p><a href="https://snyk.io/blog/prototype-pollution-minimist/">Snyk Research Blog</a></p>
-        </li>
+        <li><p><a href="https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a">Command Injection PoC</a></p></li>
+        <li><p><a href="https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94">GitHub Fix Commit #1</a></p></li>
+        <li><p><a href="https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab">GitHub Fix Commit #2</a></p></li>
+        <li><p><a href="https://snyk.io/blog/prototype-pollution-minimist/">Snyk Research Blog</a></p></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JS-MINIMIST-559764">More about this vulnerability</a></p>
@@ -2267,13 +2136,12 @@ exports[`test calling snyk-to-html from command line handles the -s argument cor
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no fixed version for <code>lodash</code>.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://hackerone.com/reports/712065">HackerOne Report</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JS-LODASH-567746">More about this vulnerability</a></p>
@@ -2312,24 +2180,17 @@ exports[`test calling snyk-to-html from command line handles the -s argument cor
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>hoek</code> to version 4.2.1, 5.0.3 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
-        <li><p><a href="https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee">GitHub Commit</a></p>
-        </li>
-        <li><p><a href="https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df">GitHub Commit</a></p>
-        </li>
-        <li><p><a href="https://github.com/hapijs/hoek/issues/230">GitHub Issue</a></p>
-        </li>
-        <li><p><a href="https://github.com/hapijs/hoek/pull/227">GitHub PR</a></p>
-        </li>
-        <li><p><a href="https://hackerone.com/reports/310439">HackerOne Report</a></p>
-        </li>
-        <li><p><a href="http://npmjs.com/advisories/566">NPM Security Advisory</a></p>
-        </li>
+        <li><p><a href="https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee">GitHub Commit</a></p></li>
+        <li><p><a href="https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df">GitHub Commit</a></p></li>
+        <li><p><a href="https://github.com/hapijs/hoek/issues/230">GitHub Issue</a></p></li>
+        <li><p><a href="https://github.com/hapijs/hoek/pull/227">GitHub PR</a></p></li>
+        <li><p><a href="https://hackerone.com/reports/310439">HackerOne Report</a></p></li>
+        <li><p><a href="http://npmjs.com/advisories/566">NPM Security Advisory</a></p></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:hoek:20180212">More about this vulnerability</a></p>
@@ -2368,14 +2229,13 @@ exports[`test calling snyk-to-html from command line handles the -s argument cor
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>ms</code> to version 2.0.0 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/zeit/ms/pull/89">GitHub PR</a></li>
         <li><a href="https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef">GitHub Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:ms:20170412">More about this vulnerability</a></p>
@@ -4872,15 +4732,14 @@ exports[`test calling snyk-to-html from command line shows remediation with vuln
               
                   </div><!-- .card__section -->
               
-                      <h2>Remediation</h2>
+                      <h2 id="remediation">Remediation</h2>
               <p>Upgrade to versions <code>1.7b2</code>, <code>1.6.3</code>, <code>1.5.6</code>, <code>1.4.11</code> or greater.</p>
-              <h2>References</h2>
+              <h2 id="references">References</h2>
               <ul>
               <li><a href="https://www.djangoproject.com/weblog/2014/apr/21/security/">Django Vulnerability Description</a></li>
               <li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0472">Redhat Bugzilla</a></li>
               <li><a href="https://rhn.redhat.com/errata/RHSA-2014-0456.html">Redhat Vulnerability Advisory</a></li>
               </ul>
-              
               
                   <div class="cta card__cta">
                       <p><a href="https://snyk.io/vuln/SNYK-PYTHON-DJANGO-40025">More about this vulnerability</a></p>
@@ -5740,18 +5599,17 @@ exports[`test calling snyk-to-html from command line shows remediation with vuln
               
                     <hr/>
                     <!-- Overview -->
-                    <h2>Overview</h2>
+                    <h2 id="overview">Overview</h2>
               <p><a href="https://pypi.python.org/pypi/Django"><code>Django</code></a> is a high-level Python Web framework that encourages rapid development and clean, pragmatic design.</p>
-              <p>Affected versions of this package are vulnerable to Arbitrary Code Execution attacks. The <code>django.core.urlresolvers.reverse</code> function allows remote attackers to import and execute arbitrary Python modules by leveraging a view that constructs URLs using user input and a &quot;dotted Python path.&quot;</p>
-              <h2>Remediation</h2>
+              <p>Affected versions of this package are vulnerable to Arbitrary Code Execution attacks. The <code>django.core.urlresolvers.reverse</code> function allows remote attackers to import and execute arbitrary Python modules by leveraging a view that constructs URLs using user input and a "dotted Python path."</p>
+              <h2 id="remediation">Remediation</h2>
               <p>Upgrade to versions <code>1.7b2</code>, <code>1.6.3</code>, <code>1.5.6</code>, <code>1.4.11</code> or greater.</p>
-              <h2>References</h2>
+              <h2 id="references">References</h2>
               <ul>
               <li><a href="https://www.djangoproject.com/weblog/2014/apr/21/security/">Django Vulnerability Description</a></li>
               <li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0472">Redhat Bugzilla</a></li>
               <li><a href="https://rhn.redhat.com/errata/RHSA-2014-0456.html">Redhat Vulnerability Advisory</a></li>
               </ul>
-              
                     <hr/>
               
                   <div class="cta card__cta">

--- a/test/__snapshots__/snyk-to-html.spec.ts.snap
+++ b/test/__snapshots__/snyk-to-html.spec.ts.snap
@@ -512,9 +512,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-CRITICAL-30078">More about this vulnerability</a></p>
@@ -553,15 +552,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>qs</code> to version <code>6.4.0</code> or higher.
         <strong>Note:</strong> The fix was backported to the following versions <code>6.3.2</code>, <code>6.2.3</code>, <code>6.1.2</code>, <code>6.0.4</code>.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d">GitHub Commit</a></li>
         <li><a href="https://github.com/ljharb/qs/issues/200">Report of an insufficient fix</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:qs:20170213">More about this vulnerability</a></p>
@@ -600,15 +598,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.zeroturnaround:zt-zip</code> to version 1.13 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff">GitHub Commit</a></li>
         <li><a href="https://snyk.io/research/zip-slip-vulnerability">Zip Slip Advisory</a></li>
         <li><a href="https://github.com/snyk/zip-slip-vulnerability">List of fixed projects that contained Zip Slip</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGZEROTURNAROUND-31681">More about this vulnerability</a></p>
@@ -647,9 +644,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/snyk:lic:maven:org.jboss.logging:jboss-logging:GPL-3.0">More about this vulnerability</a></p>
@@ -688,9 +684,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30058">More about this vulnerability</a></p>
@@ -729,9 +724,9 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.apache.struts:struts2-core</code> to version 2.3.32, 2.5.10.1 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/rapid7/metasploit-framework/pull/8072">Metasploit GitHub PR</a></li>
         <li><a href="https://github.com/rapid7/metasploit-framework/issues/8064">Metasploit GitHub Issue</a></li>
@@ -742,7 +737,6 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         <li><a href="https://cwiki.apache.org/confluence/display/WW/S2-045">Struts Wiki</a></li>
         <li><a href="http://blog.talosintelligence.com/2017/03/apache-0-day-exploited.html">Talos Intelligence Blog</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30207">More about this vulnerability</a></p>
@@ -781,9 +775,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30770">More about this vulnerability</a></p>
@@ -822,13 +815,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.apache.struts:struts2-core</code> to version 2.3.20.2, 2.3.24.2, 2.3.28.1 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3082">NVD</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30771">More about this vulnerability</a></p>
@@ -867,9 +859,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30772">More about this vulnerability</a></p>
@@ -908,9 +899,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30778">More about this vulnerability</a></p>
@@ -949,7 +939,7 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Developers are strongly advised to upgrade their <em>Apache Struts</em> components to version <code>2.3.34</code>, <code>2.5.13</code> or higher.</p>
         <p>It is possible that some REST actions stop working because of applied default restrictions on available classes. In this case please investigate the new interfaces that were introduced to allow class restrictions per action, those interfaces are:</p>
         <ul>
@@ -961,31 +951,30 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         <ol>
         <li>Disable handling XML pages and requests to such pages</li>
         </ol>
-        <pre><code class="language-xml">&lt;constant name=&quot;struts.action.extension&quot; value=&quot;xhtml,,json&quot; /&gt;
+        <pre><code class="xml language-xml">&lt;constant name="struts.action.extension" value="xhtml,,json" /&gt;
         </code></pre>
         <ol start="2">
         <li>Override getContentType in XStreamHandler</li>
         </ol>
-        <pre><code class="language-java"> public class MyXStreamHandler extends XStreamHandler { 
+        <pre><code class="java language-java"> public class MyXStreamHandler extends XStreamHandler { 
            public String getContentType() {
-             return &quot;not-existing-content-type-@;/&amp;%$#@&quot;;
+             return "not-existing-content-type-@;/&amp;%$#@";
            }
          }
         </code></pre>
         <ol start="3">
         <li>Register the handler by overriding the one provided by the framework in your struts.xml</li>
         </ol>
-        <pre><code class="language-xml">&lt;bean type=&quot;org.apache.struts2.rest.handler.ContentTypeHandler&quot; name=&quot;myXStreamHandmer&quot; class=&quot;com.company.MyXStreamHandler&quot;/&gt;
-        &lt;constant name=&quot;struts.rest.handlerOverride.xml&quot; value=&quot;myXStreamHandler&quot;/&gt;
+        <pre><code class="xml language-xml">&lt;bean type="org.apache.struts2.rest.handler.ContentTypeHandler" name="myXStreamHandmer" class="com.company.MyXStreamHandler"/&gt;
+        &lt;constant name="struts.rest.handlerOverride.xml" value="myXStreamHandler"/&gt;
         </code></pre>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://lgtm.com/blog/apache_struts_CVE-2017-9805_announcement">LGTM Advisory</a></li>
         <li><a href="https://lgtm.com/blog/apache_struts_CVE-2017-9805">LGTM Vulnerability Details</a></li>
         <li><a href="https://blogs.apache.org/foundation/entry/apache-struts-statement-on-equifax">Apache Struts Statement on Equifax Security Breach</a></li>
         <li><a href="https://cwiki.apache.org/confluence/display/WW/S2-052">Apache Security Bulletin</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31495">More about this vulnerability</a></p>
@@ -1024,14 +1013,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.apache.struts:struts2-core</code> to version 2.3.33, 2.5.12 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="http://struts.apache.org/docs/s2-049.html">Struts Security Bulletin</a></li>
         <li><a href="https://lists.apache.org/thread.html/3795c4dd46d9ec75f4a6eb9eca11c11edd3e796c6c1fd7b17b5dc50d@%3Cannouncements.struts.apache.org%3E">Struts Announcements Mailing List</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31500">More about this vulnerability</a></p>
@@ -1070,15 +1058,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.apache.struts:struts2-core</code> to versions 2.3.35, 2.5.17 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=1620019">RedHat Bugzilla Bug</a></li>
         <li><a href="https://cwiki.apache.org/confluence/display/WW/S2-057">Struts2 Security Bulletin</a></li>
         <li><a href="https://lgtm.com/blog/apache_struts_CVE-2018-11776">Lgtm Blog</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-32477">More about this vulnerability</a></p>
@@ -1117,9 +1104,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30797">More about this vulnerability</a></p>
@@ -1158,9 +1144,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30798">More about this vulnerability</a></p>
@@ -1199,9 +1184,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30799">More about this vulnerability</a></p>
@@ -1240,9 +1224,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30803">More about this vulnerability</a></p>
@@ -1281,15 +1264,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>npmconf</code> to version 2.1.3. 
         <strong>Note</strong> <code>npmconf</code> is deprecated and should not be used.
         <strong>Note</strong> This is vulnerable only for Node &lt;=4</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://hackerone.com/reports/320269">HAckerOne Report</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:npmconf:20180512">More about this vulnerability</a></p>
@@ -1328,14 +1310,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>negotiator</code> to version <code>0.6.1</code> or greater.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
-        <li><a href="https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS">https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS</a></li>
-        <li><a href="https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c">https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c</a></li>
+        <li>https://www.owasp.org/index.php/Regular<em>expression</em>Denial<em>of</em>Service<em>-</em>ReDoS</li>
+        <li>https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c</li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:negotiator:20160616">More about this vulnerability</a></p>
@@ -1374,14 +1355,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>minimatch</code> to version <code>3.0.2</code> or greater.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
-        <li><a href="https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS">https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS</a></li>
-        <li><a href="https://github.com/isaacs/minimatch/commit/6944abf9e0694bd22fd9dad293faa40c2bc8a955">https://github.com/isaacs/minimatch/commit/6944abf9e0694bd22fd9dad293faa40c2bc8a955</a></li>
+        <li>https://www.owasp.org/index.php/Regular<em>expression</em>Denial<em>of</em>Service<em>-</em>ReDoS</li>
+        <li>https://github.com/isaacs/minimatch/commit/6944abf9e0694bd22fd9dad293faa40c2bc8a955</li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:minimatch:20160620">More about this vulnerability</a></p>
@@ -1420,14 +1400,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>marked</code> to version 0.3.6 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/chjj/marked/pull/592">GitHub PR</a></li>
         <li><a href="https://github.com/chjj/marked/pull/592/commits/2cff85979be8e7a026a9aca35542c470cf5da523">GitHub Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:marked:20150520">More about this vulnerability</a></p>
@@ -1466,13 +1445,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>marked</code> to version 0.3.7 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/chjj/marked/commit/cd2f6f5b7091154c5526e79b5f3bfb4d15995a51">GitHub Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:marked:20170112">More about this vulnerability</a></p>
@@ -1511,14 +1489,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>marked</code> to version 0.3.9 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/chjj/marked/issues/925">GitHub Issue</a></li>
         <li><a href="https://github.com/chjj/marked/pull/958">GitHub Issue - Release 0.3.9 status</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:marked:20170815">More about this vulnerability</a></p>
@@ -1557,14 +1534,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>marked</code> to version 0.3.9 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/chjj/marked/issues/937">Github Issue</a></li>
         <li><a href="https://github.com/chjj/marked/pull/958">GitHub Issue - Release 0.3.9 status</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:marked:20170907">More about this vulnerability</a></p>
@@ -1603,14 +1579,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade marked to version 0.3.17 or higher</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/markedjs/marked/pull/1083">GitHub PR</a></li>
         <li><a href="https://github.com/markedjs/marked/pull/1083">GitHub Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:marked:20180225">More about this vulnerability</a></p>
@@ -1649,14 +1624,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade to a version <code>1.3</code> or above. </p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0254">NVD</a></li>
         <li><a href="https://access.redhat.com/security/cve/CVE-2015-0254">Redhat Security</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-JAVAXSERVLET-30449">More about this vulnerability</a></p>
@@ -1697,9 +1671,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/snyk:lic:npm:goof:GPL-2.0">More about this vulnerability</a></p>
@@ -1738,14 +1711,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>fresh</code> to version 0.5.2 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/jshttp/fresh/issues/24">Github Issue</a></li>
         <li><a href="https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec">Github Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:fresh:20170908">More about this vulnerability</a></p>
@@ -1784,15 +1756,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>The vulnerability can be resolved by using the GitHub integration to <a href="https://snyk.io/org/projects">generate a pull-request</a> from your dashboard or ignored by running <code>snyk ignore</code> from the command-line interface.
         Otherwise, Upgrade <code>ejs</code> to version <code>2.5.3</code> or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://snyk.io/blog/fixing-ejs-rce-vuln">Snyk Blog</a></li>
         <li><a href="https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6">Fix commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:ejs:20161128">More about this vulnerability</a></p>
@@ -1831,16 +1802,15 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade to version <code>2.6.0</code> or greater.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
-        <li><a href="https://github.com/linkedin/dustjs/pull/534/commits/884be3bb3a34a843e6fb411100088e9b02326bd4">https://github.com/linkedin/dustjs/pull/534/commits/884be3bb3a34a843e6fb411100088e9b02326bd4</a></li>
-        <li><a href="https://github.com/linkedin/dustjs/pull/534">https://github.com/linkedin/dustjs/pull/534</a></li>
-        <li><a href="https://github.com/linkedin/dustjs/issues/741">https://github.com/linkedin/dustjs/issues/741</a></li>
-        <li><a href="https://artsploit.blogspot.co.il/2016/08/pprce2.html">https://artsploit.blogspot.co.il/2016/08/pprce2.html</a></li>
+        <li>https://github.com/linkedin/dustjs/pull/534/commits/884be3bb3a34a843e6fb411100088e9b02326bd4</li>
+        <li>https://github.com/linkedin/dustjs/pull/534</li>
+        <li>https://github.com/linkedin/dustjs/issues/741</li>
+        <li>https://artsploit.blogspot.co.il/2016/08/pprce2.html</li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:dustjs-linkedin:20160819">More about this vulnerability</a></p>
@@ -1879,9 +1849,9 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>commons-fileupload:commons-fileupload</code> to version 1.3.2 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml#L84">Github ChangeLog</a></li>
         <li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=1349475">Redhat Bugzilla</a></li>
@@ -1889,7 +1859,6 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         <li><a href="http://svn.apache.org/viewvc/commons/proper/fileupload/trunk/RELEASE-NOTES.txt?r1=1745717&r2=1749637&diff_format=h">Apache-SVN</a></li>
         <li><a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092">CVE</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082">More about this vulnerability</a></p>
@@ -1928,16 +1897,15 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>commons-fileupload</code> to version 1.3.3 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1000031">NVD</a></li>
         <li><a href="http://www.tenable.com/security/research/tra-2016-12">Tenable Security</a></li>
         <li><a href="https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L65">Github ChangeLog</a></li>
         <li><a href="https://github.com/apache/commons-fileupload/commit/388e824518697c2c8f9f83fd964621d9c2f8fc4c">Github Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30401">More about this vulnerability</a></p>
@@ -1976,9 +1944,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078">More about this vulnerability</a></p>
@@ -2017,9 +1984,9 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>adm-zip</code> to version 0.4.11 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/cthackers/adm-zip/pull/212">GitHub PR</a></li>
         <li><a href="https://github.com/cthackers/adm-zip/pull/212/commits/6f4dfeb9a2166e93207443879988f97d88a37cde">GitHub Commit 0.4.9</a></li>
@@ -2027,7 +1994,6 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         <li><a href="https://snyk.io/research/zip-slip-vulnerability">Zip Slip Advisory</a></li>
         <li><a href="https://github.com/snyk/zip-slip-vulnerability">List of fixed projects that contained Zip Slip</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:adm-zip:20180415">More about this vulnerability</a></p>
@@ -2066,15 +2032,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>tunnel-agent</code> to version 0.6.0 or higher.
         <strong>Note</strong> This is vulnerable only for Node &lt;=4</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://gist.github.com/ChALkeR/fd6b2c445834244e7d440a043f9d2ff4">PoC by ChALkeR</a></li>
         <li><a href="https://github.com/request/tunnel-agent/commit/9ca95ec7219daface8a6fc2674000653de0922c0">Github Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:tunnel-agent:20170305">More about this vulnerability</a></p>
@@ -2113,9 +2078,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/snyk:lic:npm:symbol:MPL-2.0">More about this vulnerability</a></p>
@@ -2154,14 +2118,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade to version 0.2.5 or greater.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
-        <li><a href="https://github.com/isaacs/st#security-status">https://github.com/isaacs/st#security-status</a></li>
-        <li><a href="http://blog.npmjs.org/post/80277229932/newly-paranoid-maintainers">http://blog.npmjs.org/post/80277229932/newly-paranoid-maintainers</a></li>
+        <li>https://github.com/isaacs/st#security-status</li>
+        <li>http://blog.npmjs.org/post/80277229932/newly-paranoid-maintainers</li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:st:20140206">More about this vulnerability</a></p>
@@ -2200,9 +2163,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:st:20171013">More about this vulnerability</a></p>
@@ -2241,13 +2203,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
-        <p>Update to a version 4.3.2 or greater. From the issue description [2]: &quot;Package version can no longer be more than 256 characters long. This prevents a situation in which parsing the version number can use exponentially more time and memory to parse, leading to a potential denial of service.&quot;</p>
-        <h2>References</h2>
+                <h2 id="remediation">Remediation</h2>
+        <p>Update to a version 4.3.2 or greater. From the issue description [2]: "Package version can no longer be more than 256 characters long. This prevents a situation in which parsing the version number can use exponentially more time and memory to parse, leading to a potential denial of service."</p>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/npm/npm/releases/tag/v2.7.5">GitHub Release</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:semver:20150403">More about this vulnerability</a></p>
@@ -2286,15 +2247,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>request</code> to version 2.68.0 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/request/request/pull/2018">GitHub PR</a></li>
         <li><a href="https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md#previous-materials">Blog: Node Buffer API fix</a></li>
         <li><a href="https://github.com/ChALkeR/notes/blob/master/Buffer-knows-everything.md">Blog: Information about Buffer</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:request:20160119">More about this vulnerability</a></p>
@@ -2333,13 +2293,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.springframework:spring-web</code> to version 3.2.14, 4.1.7 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="http://pivotal.io/security/cve-2015-3192">Pivotal Security</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30164">More about this vulnerability</a></p>
@@ -2378,15 +2337,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.springframework:spring-web</code> to version 4.2.1.RELEASE, 4.1.7.RELEASE, 4.0.9.RELEASE, 3.2.14.RELEASE or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="http://pivotal.io/security/cve-2015-5211">Pivotal Security</a></li>
         <li><a href="https://access.redhat.com/security/cve/cve-2015-5211">Redhat Bugzilla</a></li>
         <li><a href="https://www.trustwave.com/Resources/SpiderLabs-Blog/Reflected-File-Download---A-New-Web-Attack-Vector/">Oren Hafif Blog</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30165">More about this vulnerability</a></p>
@@ -2425,9 +2383,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31331">More about this vulnerability</a></p>
@@ -2466,13 +2423,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no fix version for <code>org.springframework:spring-web</code>.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/spring-projects/spring-security/issues/3392">GitHub Issue</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31644">More about this vulnerability</a></p>
@@ -2511,9 +2467,9 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.springframework:spring-core</code> to version 3.2.9, 4.0.5 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/spring-projects/spring-framework/commit/e3e71ba92a8b82dadf474eda76cd2741f65a77a8">GitHub Commit</a></li>
         <li><a href="https://pivotal.io/security/cve-2014-3578">Pivotal Security</a></li>
@@ -2522,7 +2478,6 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         <li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=1131882">Redhat Bugzilla</a></li>
         <li><a href="https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3578">NVD</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31325">More about this vulnerability</a></p>
@@ -2561,9 +2516,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGHIBERNATE-30098">More about this vulnerability</a></p>
@@ -2602,9 +2556,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:(EPL-1.0_OR_EPL-1.0)">More about this vulnerability</a></p>
@@ -2643,9 +2596,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0">More about this vulnerability</a></p>
@@ -2684,9 +2636,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30773">More about this vulnerability</a></p>
@@ -2725,9 +2676,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30774">More about this vulnerability</a></p>
@@ -2766,9 +2716,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30775">More about this vulnerability</a></p>
@@ -2807,9 +2756,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30776">More about this vulnerability</a></p>
@@ -2848,9 +2796,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30777">More about this vulnerability</a></p>
@@ -2889,13 +2836,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.apache.struts:struts2-core</code> to version 2.3.34, 2.5.13 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="http://struts.apache.org/docs/s2-050.html">Struts Security Bulletin</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31501">More about this vulnerability</a></p>
@@ -2934,13 +2880,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.apache.struts:struts2-core</code> to version 2.3.34, 2.5.13 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="http://struts.apache.org/docs/s2-051.html">Struts Security Bulletin</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31502">More about this vulnerability</a></p>
@@ -2979,13 +2924,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Developers are strongly advised to upgrade their <em>Apache Struts</em> components to version <code>2.3.34</code>, <code>2.5.12</code> or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://cwiki.apache.org/confluence/display/WW/S2-053">Apache Security Bulletin</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31503">More about this vulnerability</a></p>
@@ -3024,9 +2968,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30800">More about this vulnerability</a></p>
@@ -3065,9 +3008,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30801">More about this vulnerability</a></p>
@@ -3106,9 +3048,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30802">More about this vulnerability</a></p>
@@ -3147,9 +3088,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30804">More about this vulnerability</a></p>
@@ -3188,14 +3128,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>ognl:ognl</code> to version 3.0.12 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093">NVD</a></li>
         <li><a href="https://github.com/jkuhnert/ognl/commit/ae43073fbf38db8371ff4f8bf2a966ee3b5f7e92">GitHub Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-OGNL-30474">More about this vulnerability</a></p>
@@ -3234,13 +3173,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>ms</code> to version 0.7.1.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS">OWASP - ReDoS</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:ms:20151024">More about this vulnerability</a></p>
@@ -3279,15 +3217,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>mongoose</code> to version &gt;= 3.8.39 or &gt;= 4.3.6.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/Automattic/mongoose/issues/3764">GitHub Issue</a></li>
         <li><a href="https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md#previous-materials">Blog: Node Buffer API fix</a></li>
         <li><a href="https://github.com/ChALkeR/notes/blob/master/Buffer-knows-everything.md">Blog: Information about Buffer</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:mongoose:20160116">More about this vulnerability</a></p>
@@ -3326,9 +3263,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:moment:20161019">More about this vulnerability</a></p>
@@ -3367,14 +3303,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>marked</code> to version 0.3.9 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/chjj/marked/issues/926">GitHub Issue</a></li>
         <li><a href="https://github.com/chjj/marked/pull/958">GitHub Issue - Release 0.3.9 status</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:marked:20170815-1">More about this vulnerability</a></p>
@@ -3413,16 +3348,15 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>jquery</code> to version <code>3.0.0</code> or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/jquery/jquery/issues/2432">GitHub Issue</a></li>
         <li><a href="https://github.com/jquery/jquery/pull/2588">GitHub PR</a></li>
         <li><a href="https://github.com/jquery/jquery/pull/2588/commits/c254d308a7d3f1eac4d0b42837804cfffcba4bb2">GitHub Commit 3.0.0</a></li>
         <li><a href="https://github.com/jquery/jquery/commit/f60729f3903d17917dc351f3ac87794de379b0cc">GitHub Commit 1.12</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:jquery:20150627">More about this vulnerability</a></p>
@@ -3461,14 +3395,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>http-signature</code> to version 1.0.0 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/joyent/node-http-signature/pull/36">Github PR</a></li>
         <li><a href="https://github.com/joyent/node-http-signature/commit/78ab1da232f31f695f5c362d863593a143aa8b56">Github Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:http-signature:20150122">More about this vulnerability</a></p>
@@ -3507,15 +3440,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>The vulnerability can be resolved by using the GitHub integration to <a href="https://snyk.io/org/projects">generate a pull-request</a> from your dashboard or ignored by running <code>snyk ignore</code> from the command-line interface.
         Otherwise, Upgrade <code>ejs</code> to version <code>2.5.5</code> or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://snyk.io/blog/fixing-ejs-rce-vuln">Snyk Blog</a></li>
         <li><a href="https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f">Fix commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:ejs:20161130">More about this vulnerability</a></p>
@@ -3554,15 +3486,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>The vulnerability can be resolved by using the GitHub integration to <a href="https://snyk.io/org/projects">generate a pull-request</a> from your dashboard or ignored by running <code>snyk ignore</code> from the command-line interface.
         Otherwise, Upgrade <code>ejs</code> to version <code>2.5.5</code> or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://snyk.io/blog/fixing-ejs-rce-vuln">Snyk Blog</a></li>
         <li><a href="https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f">Fix commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:ejs:20161130-1">More about this vulnerability</a></p>
@@ -3601,14 +3532,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade to version 4.1.2 and higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/hapijs/cryptiles/issues/34">GitHub Issue</a></li>
         <li><a href="https://github.com/hapijs/cryptiles/commit/9332d4263a32b84e76bf538d7470d01ea63fa047">GitHub Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:cryptiles:20180710">More about this vulnerability</a></p>
@@ -3647,14 +3577,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>commons-fileupload</code> to version 1.3.2 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L56">Github ChangeLog</a></li>
         <li><a href="https://github.com/apache/commons-fileupload/commit/5b4881d7f75f439326f54fa554a9ca7de6d60814">Github Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-31540">More about this vulnerability</a></p>
@@ -3693,15 +3622,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>brace-expansion</code> to version 1.1.7 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/juliangruber/brace-expansion/pull/35">GitHub PR</a></li>
         <li><a href="https://github.com/juliangruber/brace-expansion/issues/33">GitHub Issue</a></li>
         <li><a href="https://github.com/juliangruber/brace-expansion/pull/35/commits/b13381281cead487cbdbfd6a69fb097ea5e456c3">GitHub Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:brace-expansion:20170302">More about this vulnerability</a></p>
@@ -3740,14 +3668,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>org.springframework:spring-web</code> to versions 3.2.8, 4.0.4 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="http://www.gopivotal.com/security/cve-2014-0225">Pivotal Security</a></li>
         <li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0225">Redhat Bugzilla</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30163">More about this vulnerability</a></p>
@@ -3786,9 +3713,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30060">More about this vulnerability</a></p>
@@ -3827,14 +3753,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>ms</code> to version 2.0.0 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/zeit/ms/pull/89">GitHub PR</a></li>
         <li><a href="https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef">GitHub Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:ms:20170412">More about this vulnerability</a></p>
@@ -3873,13 +3798,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>moment</code> to version <code>2.19.3</code> or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/moment/moment/issues/4163">GitHub Issue</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:moment:20170905">More about this vulnerability</a></p>
@@ -3918,15 +3842,14 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>mime</code> to versions 1.4.1, 2.0.3 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/broofa/node-mime/issues/167">Github Issue</a></li>
         <li><a href="https://github.com/broofa/node-mime/commit/855d0c4b8b22e4a80b9401a81f2872058eae274d">Github Commit 1.x</a></li>
         <li><a href="https://github.com/broofa/node-mime/commit/1df903fdeb9ae7eaa048795b8d580ce2c98f40b0">Github Commit 2.0.x</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:mime:20170907">More about this vulnerability</a></p>
@@ -3965,9 +3888,9 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>hoek</code> to versions 4.2.1, 5.0.3 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://hackerone.com/reports/310439">HackerOne Report</a></li>
         <li><a href="https://github.com/hapijs/hoek/pull/227">GitHub PR</a></li>
@@ -3975,7 +3898,6 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         <li><a href="https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee">GitHub Commit 5.0.3</a></li>
         <li><a href="https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df">GitHub Commit 4.2.x</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:hoek:20180212">More about this vulnerability</a></p>
@@ -4014,9 +3936,8 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>There is no remediation at the moment</p>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:hawk:20160119">More about this vulnerability</a></p>
@@ -4055,14 +3976,13 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>debug</code> to version 2.6.9, 3.1.0 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/visionmedia/debug/issues/501">GitHub Issue</a></li>
         <li><a href="https://github.com/visionmedia/debug/pull/504">GitHub PR</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:debug:20170905">More about this vulnerability</a></p>
@@ -4101,13 +4021,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>bson</code> to version 1.0.5 or higher</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/mongodb/js-bson/commit/bd61c45157c53a1698ff23770160cf4783e9ea4a">GitHub Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:bson:20180225">More about this vulnerability</a></p>
@@ -4146,13 +4065,12 @@ exports[`test running SnykToHtml.run displays vulns in descending order of sever
         
             </div><!-- .card__section -->
         
-                <h2>Remediation</h2>
+                <h2 id="remediation">Remediation</h2>
         <p>Upgrade <code>braces</code> to version 2.3.1 or higher.</p>
-        <h2>References</h2>
+        <h2 id="references">References</h2>
         <ul>
         <li><a href="https://github.com/micromatch/braces/commit/abdafb0cae1e0c00f184abbadc692f4eaa98f451">GitHub Commit</a></li>
         </ul>
-        
         
             <div class="cta card__cta">
                 <p><a href="https://snyk.io/vuln/npm:braces:20180219">More about this vulnerability</a></p>

--- a/test/snyk-from-commandline.spec.ts
+++ b/test/snyk-from-commandline.spec.ts
@@ -36,7 +36,7 @@ describe('test calling snyk-to-html from command line', () => {
     expect(stderr).toEqual('');
 
     const cleanedReport = cleanTimestamp(stdout);
-    expect(cleanedReport).not.toContain('<h2>Overview</h2>');
+    expect(cleanedReport).not.toContain('<h2 id="overview">Overview</h2>');
     expect(cleanedReport).toMatchSnapshot();
   });
 
@@ -76,9 +76,9 @@ describe('test calling snyk-to-html from command line', () => {
 
       const cleanedReport = cleanTimestamp(stdout);
       if (args.includes('--summary')) {
-        expect(cleanedReport).not.toContain('<h2>Overview</h2>');
+        expect(cleanedReport).not.toContain('<h2 id="overview">Overview</h2>');
       } else {
-        expect(cleanedReport).toContain('<h2>Overview</h2>');
+        expect(cleanedReport).toContain('<h2 id="overview">Overview</h2>');
       }
 
       expect(cleanedReport).toContain(
@@ -148,7 +148,7 @@ describe('test calling snyk-to-html from command line', () => {
     expect(stderr).toEqual('');
 
     const cleanedReport = cleanTimestamp(stdout);
-    expect(cleanedReport).not.toContain('<h2>Overview</h2>');
+    expect(cleanedReport).not.toContain('<h2 id="overview">Overview</h2>');
     expect(cleanedReport).toContain('<strong>14</strong> high issues');
     expect(cleanedReport).toContain('<strong>5</strong> medium issues');
     expect(cleanedReport).toContain('<li class="card__meta__item">CWE-79</li>');
@@ -177,8 +177,8 @@ describe('test calling snyk-to-html from command line', () => {
     expect(cleanedReport).toContain(
       '<div class="meta-count"><span>4</span> <span>dependencies</span></div>',
     );
-    expect(cleanedReport).toContain('<h2>Overview</h2>');
-    expect(cleanedReport).toContain('<h2>Remediation</h2>');
+    expect(cleanedReport).toContain('<h2 id="overview">Overview</h2>');
+    expect(cleanedReport).toContain('<h2 id="remediation">Remediation</h2>');
     expect(cleanedReport).toContain(
       '<p>Upgrade <code>curl</code> to version 7.60.0 or higher.</p>',
     );

--- a/test/snyk-to-html.spec.ts
+++ b/test/snyk-to-html.spec.ts
@@ -26,8 +26,8 @@ describe('test running SnykToHtml.run', () => {
           expect(report).toContain(
             '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>',
           );
-          expect(report).toContain('<h2>Overview</h2>');
-          expect(report).toContain('<h2>Details</h2>');
+          expect(report).toContain('<h2 id="overview">Overview</h2>');
+          expect(report).toContain('<h2 id="details">Details</h2>');
           expect(report).not.toContain('<div class="suppression-card">');
           done();
         } catch (error: any) {
@@ -60,8 +60,8 @@ describe('test running SnykToHtml.run', () => {
           expect(report).toContain(
             '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>',
           );
-          expect(report).toContain('<h2>Overview</h2>');
-          expect(report).toContain('<h2>Details</h2>');
+          expect(report).toContain('<h2 id="overview">Overview</h2>');
+          expect(report).toContain('<h2 id="details">Details</h2>');
           done();
         } catch (error: any) {
           done(error);
@@ -93,8 +93,8 @@ describe('test running SnykToHtml.run', () => {
           expect(report).toContain(
             '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>',
           );
-          expect(report).not.toContain('<h2>Overview</h2>');
-          expect(report).not.toContain('<h2>Details</h2>');
+          expect(report).not.toContain('<h2 id="overview">Overview</h2>');
+          expect(report).not.toContain('<h2 id="details">Details</h2>');
           done();
         } catch (error: any) {
           done(error);
@@ -212,8 +212,8 @@ describe('test running SnykToHtml.run', () => {
           expect(report).toContain(
             '<h2 class="card__title">Regular Expression Denial of Service (DoS)</h2>',
           );
-          expect(report).not.toContain('<h2>Overview</h2>');
-          expect(report).not.toContain('<h2>Details</h2>');
+          expect(report).not.toContain('<h2 id="overview">Overview</h2>');
+          expect(report).not.toContain('<h2 id="details">Details</h2>');
           done();
         } catch (error: any) {
           done(error);
@@ -238,8 +238,8 @@ describe('test running SnykToHtml.run', () => {
             '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)</h2>',
           );
           expect(report).toContain('Fixed in: 2.9.10');
-          expect(report).not.toContain('<h2>Overview</h2>');
-          expect(report).not.toContain('<h2>Details</h2>');
+          expect(report).not.toContain('<h2 id="overview">Overview</h2>');
+          expect(report).not.toContain('<h2 id="details">Details</h2>');
           done();
         } catch (error: any) {
           done(error);
@@ -264,8 +264,8 @@ describe('test running SnykToHtml.run', () => {
             '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)</h2>',
           );
           expect(report).toContain('Fixed in: 2.9.10, 4.5.6');
-          expect(report).not.toContain('<h2>Overview</h2>');
-          expect(report).not.toContain('<h2>Details</h2>');
+          expect(report).not.toContain('<h2 id="overview">Overview</h2>');
+          expect(report).not.toContain('<h2 id="details">Details</h2>');
           done();
         } catch (error: any) {
           done(error);
@@ -290,8 +290,8 @@ describe('test running SnykToHtml.run', () => {
             '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)</h2>',
           );
           expect(report).toContain('There is no remediation at the moment');
-          expect(report).not.toContain('<h2>Overview</h2>');
-          expect(report).not.toContain('<h2>Details</h2>');
+          expect(report).not.toContain('<h2 id="overview">Overview</h2>');
+          expect(report).not.toContain('<h2 id="details">Details</h2>');
           done();
         } catch (error: any) {
           done(error);


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commits are squashed and tidy and are suitable to become release notes

### What this does

An update of very outdated dependencies (https://github.com/snyk/snyk-to-html/pull/211) caused an esoteric bug to disclose itself on Azure Pipelines, when embedded dynamically in an iframe. The issues was reported as a [bug](https://github.com/markedjs/marked/issues/3546) but the root cause is not clear.

Instead of spending too much time on browser compatibility issues this PR will introduce another markdown-to-html library with a smaller surface.

### Notes for the reviewer

Since no VRTs needs updating it suggests everything should look exactly the same.

### More information

N/A

### Screenshots

N/A
