### PR TITLE
feat: expose epssDetails and identifiers in vulnerability metadata

### DIFF
--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -197,6 +197,8 @@ function metadataForVuln(vuln: any) {
     publicationTime: dateFromDateTimeString(vuln.publicationTime || ''),
     license: vuln.license || undefined,
     exploitMaturity: getExploitMaturity(vuln),
+    epssDetails: vuln.epssDetails || undefined,
+    identifiers: vuln.identifiers || undefined,
   };
 }
 


### PR DESCRIPTION
### What this does

Adds two new fields to the `metadataForVuln` function so that EPSS details and CVE identifiers are passed through to the Handlebars template context:

- `epssDetails`: exposes the EPSS probability and percentile data (e.g. `{ probability: "0.00196", percentile: "0.41530" }`) for display in vulnerability cards
- `identifiers`: exposes the CVE/CWE/GHSA identifiers (e.g. `{ CVE: ["CVE-2022-25881"], CWE: ["CWE-1333"] }`) for display in vulnerability cards
<img width="547" height="148" alt="Capture d&#39;écran 2026-03-01 101054" src="https://github.com/user-attachments/assets/4029a49c-2605-4af4-b97f-73ecb7788500" />

These fields are already present in the `snyk test` CLI JSON output but were not being forwarded to the template rendering context, making it impossible to reference `{{metadata.epssDetails.probability}}` or `{{metadata.identifiers.CVE}}` in templates.

### Notes for the reviewer

- Non-breaking change, adds optional fields to the metadata object; `undefined` when absent
- No template files are modified; this only makes the data available for downstream template consumers
- No new dependencies
- Follows the existing `|| undefined` pattern used by the `license` field in the same function
- Existing tests continue to pass;

### Screenshots

No visual changes, this is a data passthrough only. 
Template consumers can now use these fields to render EPSS scores and CVE badges

