### PR TITLE
feat: Add support for additional metadata fields for use with custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ node ./dist/index.js
 
 When in doubt, use `snyk-to-html --help` or `snyk-to-html -h`.
 
+### Custom templates
+
+Use the `-t` or `--template` option to supply your own Handlebars template for dependency and container reports. Each vulnerability card receives a `metadata` object (and a `list` of vuln instances). The following fields are available on `metadata` for use in custom templates:
+
+| Category              | Fields |
+| --------------------- | ------ |
+| Core                  | `id`, `title`, `name`, `info`, `severity`, `severityValue`, `description`, `fixedIn`, `packageManager`, `version`, `cvssScore`, `license` |
+| CVE/identifiers       | `cveSpaced`, `cveLineBreaks`, `identifiers` (object with `CVE`, `CWE`, `GHSA` arrays) |
+| Dates                 | `disclosureTime`, `publicationTime` |
+| Risk and reachability | `riskScore`, `reachability`, `exploitMaturity` |
+| EPSS                  | `epssDetails` (when present: `modelVersion`, `percentile`, `probability`) |
+
+Use `{{#if metadata.epssDetails}}` or `{{#if metadata.identifiers}}` before accessing these, as they may be absent or null for some vulnerabilities.
+
 ## Generate the HTML report
 
 Snyk JSON to HTML Mapper mapper works with the different Snyk Products.  Change the directory to your package's root folder, then use  one of the  ways below to generate the HTML report, using the appropriate product's command

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -197,6 +197,8 @@ function metadataForVuln(vuln: any) {
     publicationTime: dateFromDateTimeString(vuln.publicationTime || ''),
     license: vuln.license || undefined,
     exploitMaturity: getExploitMaturity(vuln),
+    epssDetails: vuln.epssDetails ?? undefined,
+    identifiers: vuln.identifiers ?? undefined,
   };
 }
 

--- a/template/test-report.additionalFields.hbs
+++ b/template/test-report.additionalFields.hbs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body>
+{{#each vulnerabilities}}
+<div class="vuln-metadata">
+  {{#if metadata.epssDetails}}
+  <span class="epss-probability">{{metadata.epssDetails.probability}}</span>
+  <span class="epss-percentile">{{metadata.epssDetails.percentile}}</span>
+  {{/if}}
+  {{#if metadata.identifiers}}
+  {{#each metadata.identifiers.CWE}}
+  <span class="cwe-id">{{this}}</span>
+  {{/each}}
+  {{/if}}
+</div>
+{{/each}}
+</body>
+</html>

--- a/test/snyk-to-html.spec.ts
+++ b/test/snyk-to-html.spec.ts
@@ -682,6 +682,34 @@ describe('test running SnykToHtml.run', () => {
     );
   });
 
+  it('exposes epssDetails and identifiers in metadata for custom templates', (done) => {
+    SnykToHtml.run(
+      path.join(__dirname, 'fixtures', 'test-report-with-reachability.json'),
+      WITHOUT_REMEDIATION,
+      path.join(
+        __dirname,
+        '..',
+        'template',
+        'test-report.additionalFields.hbs',
+      ),
+      WITHOUT_SUMMARY,
+      (report) => {
+        try {
+          expect(report).toContain(
+            '<span class="epss-probability">0.00328</span>',
+          );
+          expect(report).toContain(
+            '<span class="epss-percentile">0.55188</span>',
+          );
+          expect(report).toContain('<span class="cwe-id">CWE-79</span>');
+          done();
+        } catch (error: any) {
+          done(error);
+        }
+      },
+    );
+  });
+
   describe('exploit maturity handling', () => {
     // Helper function to extract card content for a specific vulnerability
     const getCardContent = (report: string, vulnId: string): string => {


### PR DESCRIPTION
### What this does

Exposes `epssDetails` and `identifiers` in the Handlebars template context so custom HTML templates can render EPSS scores and CWE/CVE/GHSA data. Addresses the customer request to use EPSS in custom reports for risk-based vulnerability management.

### Changes
- **`metadataForVuln()`** ([src/lib/snyk-to-html.ts](src/lib/snyk-to-html.ts))
  - Adds two pass-through fields to the metadata object passed to templates:
    - **`epssDetails`** — when present: `modelVersion`, `percentile`, `probability` (or `undefined` when null/absent).
    - **`identifiers`** — object with `CVE`, `CWE`, and `GHSA` arrays (or `undefined` when absent).
  - Uses `?? undefined` so only `null`/`undefined` are normalized; other values are left as-is.
- **Tests**
  - Adds [template/test-report.additionalFields.hbs](template/test-report.additionalFields.hbs), a minimal template that renders `metadata.epssDetails` and `metadata.identifiers.CWE`.
  - Adds a spec: **"exposes epssDetails and identifiers in metadata for custom templates"**, which runs with `test-report-with-reachability.json` and asserts the generated HTML contains the expected EPSS and CWE values.
- **Documentation** ([README.md](README.md))
  - Adds a **Custom templates** subsection that:
    - Describes using `-t` / `--template` for dependency and container reports.
    - Documents available `metadata` fields in a markdown table (Core, CVE/identifiers, Dates, Risk and reachability, EPSS).
    - Recommends `{{#if metadata.epssDetails}}` and `{{#if metadata.identifiers}}` for optional fields.
    
### Impact
- **Default template / existing users**  
  No change. The default templates do not reference `epssDetails` or `identifiers`, so default report output and existing tests (including reachability and exploit maturity) are unchanged.
- **Custom template users**  
  Additive only: they can now use `metadata.epssDetails` and `metadata.identifiers` (e.g. `metadata.identifiers.CWE`, `metadata.identifiers.CVE`). Templates that iterate over `metadata` will see two new keys; null/undefined handling is documented.