### PR TITLE
fix: handle missing fields when building actionable remediation report

### DIFF
--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -12,6 +12,7 @@ import {
   addIssueDataToPatch,
   getUpgrades,
   IacProjectType,
+  normalizeRemediationChanges,
   severityMap,
 } from './vuln';
 import {
@@ -252,7 +253,8 @@ async function generateTemplate(
 ): Promise<string> {
   if (showRemediation && data.remediation) {
     data.showRemediations = showRemediation;
-    const { upgrade, pin, unresolved, patch } = data.remediation;
+    const remediation: any = normalizeRemediationChanges(data.remediation);
+    const { upgrade, pin, unresolved, patch } = remediation;
     data.anyRemediations =
       !isEmpty(upgrade) || !isEmpty(patch) || !isEmpty(pin);
     data.anyUnresolved = !!unresolved?.vulnerabilities;

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -257,7 +257,7 @@ async function generateTemplate(
     const { upgrade, pin, unresolved, patch } = remediation;
     data.anyRemediations =
       !isEmpty(upgrade) || !isEmpty(patch) || !isEmpty(pin);
-    data.anyUnresolved = !!unresolved?.vulnerabilities;
+    data.anyUnresolved = Array.isArray(unresolved) && unresolved.length > 0;
     data.unresolved = groupVulns(unresolved);
     data.upgrades = getUpgrades(upgrade, data.vulnerabilities);
     data.pins = getUpgrades(pin, data.vulnerabilities);

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -253,7 +253,7 @@ async function generateTemplate(
 ): Promise<string> {
   if (showRemediation && data.remediation) {
     data.showRemediations = showRemediation;
-    const remediation: any = normalizeRemediationChanges(data.remediation);
+    const remediation = normalizeRemediationChanges(data.remediation)!;
     const { upgrade, pin, unresolved, patch } = remediation;
     data.anyRemediations =
       !isEmpty(upgrade) || !isEmpty(patch) || !isEmpty(pin);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,14 @@ export interface Vuln {
   severity: string;
 }
 
+export interface RemediationChanges {
+  unresolved?: unknown[];
+  upgrade?: Record<string, unknown>;
+  patch?: Record<string, unknown>;
+  ignore?: Record<string, unknown>;
+  pin?: Record<string, unknown>;
+}
+
 export type SuppressionStatus = 'accepted' | 'rejected' | 'underReview';
 
 export interface Suppression {

--- a/src/lib/vuln.ts
+++ b/src/lib/vuln.ts
@@ -1,5 +1,26 @@
 import * as orderBy from 'lodash.orderby';
-import { PatchRemediation, UpgradeRemediation, Vuln } from './types';
+import {
+  PatchRemediation,
+  RemediationChanges,
+  UpgradeRemediation,
+  Vuln,
+} from './types';
+
+export function normalizeRemediationChanges(
+  remediation?: RemediationChanges,
+): RemediationChanges | undefined {
+  if (!remediation) {
+    return undefined;
+  }
+
+  return {
+    unresolved: remediation.unresolved ?? [],
+    upgrade: remediation.upgrade ?? {},
+    patch: remediation.patch ?? {},
+    ignore: remediation.ignore ?? {},
+    pin: remediation.pin ?? {},
+  };
+}
 
 export const severityMap = { low: 0, medium: 1, high: 2, critical: 3 };
 

--- a/test/__snapshots__/snyk-from-commandline.spec.ts.snap
+++ b/test/__snapshots__/snyk-from-commandline.spec.ts.snap
@@ -822,6 +822,183 @@ exports[`test calling snyk-to-html from command line handles the -a argument cor
         </div>
       </section>
 
+      <!-- unresolved -->
+      <section class="layout-container" style="padding-top: 35px;">
+        <h2>Issues with no direct upgrade or patch</h2>
+          <div class="card card--vuln  disclosure--not-new severity--medium" data-snyk-test="medium">
+              <h2 class="card__title">Prototype Pollution</h2>
+              <div class="card__section">
+          
+                  <div class="card__labels">
+                      <div class="label label--medium">
+                          <span class="label__text">medium severity</span>
+                      </div>
+                      <div class="label label--exploit">
+                          <span class="label__text">Exploit: Proof of Concept</span>
+                      </div>
+                  </div>
+          
+                  <hr/>
+          
+                  <ul class="card__meta">
+                      <li class="card__meta__item">
+                          Package Manager: npm
+                      </li>
+                      <li class="card__meta__item">
+                              Vulnerable module:
+          
+                              minimist
+                      </li>
+          
+                      <li class="card__meta__item">Introduced through:
+          
+          
+                                      npm-two-vuln-deps@1.0.0, sharp@0.17.3 and others
+                      </li>
+                  </ul>
+          
+                  <hr/>
+          
+          
+                          <h3 class="card__section__title">Detailed paths</h3>
+          
+                      <ul class="card__meta__paths">
+                                  <li>
+                                  <span class="list-paths__item__introduced"><em>Introduced through</em>:
+                                          npm-two-vuln-deps@1.0.0
+                                           <span class="list-paths__item__arrow">›</span> 
+                                          sharp@0.17.3
+                                           <span class="list-paths__item__arrow">›</span> 
+                                          tar@2.2.2
+                                           <span class="list-paths__item__arrow">›</span> 
+                                          fstream@1.0.12
+                                           <span class="list-paths__item__arrow">›</span> 
+                                          mkdirp@0.5.1
+                                           <span class="list-paths__item__arrow">›</span> 
+                                          minimist@0.0.8
+                                          
+                                  </span>
+          
+                              </li>
+                      </ul><!-- .list-paths -->
+          
+              </div><!-- .card__section -->
+          
+                <hr/>
+                <!-- Overview -->
+                <h2 id="overview">Overview</h2>
+          <p><a href="https://www.npmjs.com/package/minimist">minimist</a> is a parse argument options module.</p>
+          <p>Affected versions of this package are vulnerable to Prototype Pollution.
+          The library could be tricked into adding or modifying properties of <code>Object.prototype</code> using a <code>constructor</code> or <code>__proto__</code> payload.</p>
+          <h2 id="poc-by-snyk">PoC by Snyk</h2>
+          <pre><code>require(&#39;minimist&#39;)(&#39;--__proto__.injected0 value0&#39;.split(&#39; &#39;));
+          console.log(({}).injected0 === &#39;value0&#39;); // true
+          
+          require(&#39;minimist&#39;)(&#39;--constructor.prototype.injected1 value1&#39;.split(&#39; &#39;));
+          console.log(({}).injected1 === &#39;value1&#39;); // true
+          </code></pre>
+          <h2 id="details">Details</h2>
+          <p>Prototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as <code>_proto_</code>, <code>constructor</code> and <code>prototype</code>. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the <code>Object.prototype</code> are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.</p>
+          <p>There are two main ways in which the pollution of prototypes occurs:</p>
+          <ul>
+          <li><p>Unsafe <code>Object</code> recursive merge</p>
+          </li>
+          <li><p>Property definition by path</p>
+          </li>
+          </ul>
+          <h3 id="unsafe-object-recursive-merge">Unsafe Object recursive merge</h3>
+          <p>The logic of a vulnerable recursive merge function follows the following high-level model:</p>
+          <pre><code>merge (target, source)
+          
+            foreach property of source
+          
+              if property exists and is an object on both the target and the source
+          
+                merge(target[property], source[property])
+          
+              else
+          
+                target[property] = source[property]
+          </code></pre>
+          <br>  
+          
+          <p>When the source object contains a property named <code>_proto_</code> defined with <code>Object.defineProperty()</code> , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of <code>Object</code> and the source of <code>Object</code> as defined by the attacker. Properties are then copied on the <code>Object</code> prototype.</p>
+          <p>Clone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: <code>merge({},source)</code>.</p>
+          <p><code>lodash</code> and <code>Hoek</code> are examples of libraries susceptible to recursive merge attacks.</p>
+          <h3 id="property-definition-by-path">Property definition by path</h3>
+          <p>There are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: <code>theFunction(object, path, value)</code></p>
+          <p>If the attacker can control the value of “path”, they can set this value to <code>_proto_.myValue</code>. <code>myValue</code> is then assigned to the prototype of the class of the object.</p>
+          <h2 id="types-of-attacks">Types of attacks</h2>
+          <p>There are a few methods by which Prototype Pollution can be manipulated:</p>
+          <table>
+          <thead>
+          <tr>
+          <th>Type</th>
+          <th>Origin</th>
+          <th>Short description</th>
+          </tr>
+          </thead>
+          <tbody><tr>
+          <td><strong>Denial of service (DoS)</strong></td>
+          <td>Client</td>
+          <td>This is the most likely attack. <br>DoS occurs when <code>Object</code> holds generic functions that are implicitly called for various operations (for example, <code>toString</code> and <code>valueOf</code>). <br> The attacker pollutes <code>Object.prototype.someattr</code> and alters its state to an unexpected value such as <code>Int</code> or <code>Object</code>. In this case, the code fails and is likely to cause a denial of service.  <br><strong>For example:</strong> if an attacker pollutes <code>Object.prototype.toString</code> by defining it as an integer, if the codebase at any point was reliant on <code>someobject.toString()</code> it would fail.</td>
+          </tr>
+          <tr>
+          <td><strong>Remote Code Execution</strong></td>
+          <td>Client</td>
+          <td>Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br><strong>For example:</strong> <code>eval(someobject.someattr)</code>. In this case, if the attacker pollutes <code>Object.prototype.someattr</code> they are likely to be able to leverage this in order to execute code.</td>
+          </tr>
+          <tr>
+          <td><strong>Property Injection</strong></td>
+          <td>Client</td>
+          <td>The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  <strong>For example:</strong> if a codebase checks privileges for <code>someuser.isAdmin</code>, then when the attacker pollutes <code>Object.prototype.isAdmin</code> and sets it to equal <code>true</code>, they can then achieve admin privileges.</td>
+          </tr>
+          </tbody></table>
+          <h2 id="affected-environments">Affected environments</h2>
+          <p>The following environments are susceptible to a Prototype Pollution attack:</p>
+          <ul>
+          <li><p>Application server</p>
+          </li>
+          <li><p>Web server</p>
+          </li>
+          </ul>
+          <h2 id="how-to-prevent">How to prevent</h2>
+          <ol>
+          <li><p>Freeze the prototype— use <code>Object.freeze (Object.prototype)</code>.</p>
+          </li>
+          <li><p>Require schema validation of JSON input.</p>
+          </li>
+          <li><p>Avoid using unsafe recursive merge functions.</p>
+          </li>
+          <li><p>Consider using objects without prototypes (for example, <code>Object.create(null)</code>), breaking the prototype chain and preventing pollution.</p>
+          </li>
+          <li><p>As a best practice use <code>Map</code> instead of <code>Object</code>.</p>
+          </li>
+          </ol>
+          <h3 id="for-more-information-on-this-vulnerability-type">For more information on this vulnerability type:</h3>
+          <p><a href="https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf">Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018</a></p>
+          <h2 id="remediation">Remediation</h2>
+          <p>Upgrade <code>minimist</code> to version 0.2.1, 1.2.3 or higher.</p>
+          <h2 id="references">References</h2>
+          <ul>
+          <li><p><a href="https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a">Command Injection PoC</a></p>
+          </li>
+          <li><p><a href="https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94">GitHub Fix Commit #1</a></p>
+          </li>
+          <li><p><a href="https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab">GitHub Fix Commit #2</a></p>
+          </li>
+          <li><p><a href="https://snyk.io/blog/prototype-pollution-minimist/">Snyk Research Blog</a></p>
+          </li>
+          </ul>
+          
+                <hr/>
+          
+              <div class="cta card__cta">
+                  <p><a href="https://snyk.io/vuln/SNYK-JS-MINIMIST-559764">More about this vulnerability</a></p>
+              </div>
+          
+          </div><!-- .card -->
+      </section><!-- end unresolved -->
 
       <div class="layout-container" style="padding-top: 35px;">
           <div class="cards--vuln filter--patch filter--ignore">
@@ -4983,6 +5160,59 @@ exports[`test calling snyk-to-html from command line shows remediation with vuln
         </div>
       </section>
 
+      <!-- unresolved -->
+      <section class="layout-container" style="padding-top: 35px;">
+        <h2>Issues with no direct upgrade or patch</h2>
+          <div class="card card--vuln  disclosure--not-new severity--medium" data-snyk-test="medium">
+              <h2 class="card__title">Arbitrary Code Execution</h2>
+              <div class="card__section">
+          
+                  <div class="card__labels">
+                      <div class="label label--medium">
+                          <span class="label__text">medium severity</span>
+                      </div>
+                  </div>
+          
+                  <hr/>
+          
+                  <ul class="card__meta">
+                      <li class="card__meta__item">
+                          Package Manager: pip
+                      </li>
+                      <li class="card__meta__item">
+                              Vulnerable module:
+          
+                              django
+                      </li>
+          
+                      <li class="card__meta__item">Introduced through:
+          
+                                  python-pip-app-with-vulns@0.0.0 and django@1.6.1
+          
+                      </li>
+                  </ul>
+          
+                  <hr/>
+          
+          
+              </div><!-- .card__section -->
+          
+                  <h2 id="remediation">Remediation</h2>
+          <p>Upgrade to versions <code>1.7b2</code>, <code>1.6.3</code>, <code>1.5.6</code>, <code>1.4.11</code> or greater.</p>
+          <h2 id="references">References</h2>
+          <ul>
+          <li><a href="https://www.djangoproject.com/weblog/2014/apr/21/security/">Django Vulnerability Description</a></li>
+          <li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0472">Redhat Bugzilla</a></li>
+          <li><a href="https://rhn.redhat.com/errata/RHSA-2014-0456.html">Redhat Vulnerability Advisory</a></li>
+          </ul>
+          
+          
+              <div class="cta card__cta">
+                  <p><a href="https://snyk.io/vuln/SNYK-PYTHON-DJANGO-40025">More about this vulnerability</a></p>
+              </div>
+          
+          </div><!-- .card -->
+      </section><!-- end unresolved -->
 
       <div class="layout-container" style="padding-top: 35px;">
           <div class="cards--vuln filter--patch filter--ignore">
@@ -5873,6 +6103,79 @@ exports[`test calling snyk-to-html from command line shows remediation with vuln
         </div>
       </section>
 
+      <!-- unresolved -->
+      <section class="layout-container" style="padding-top: 35px;">
+        <h2>Issues with no direct upgrade or patch</h2>
+          <div class="card card--vuln  disclosure--not-new severity--medium" data-snyk-test="medium">
+              <h2 class="card__title">Arbitrary Code Execution</h2>
+              <div class="card__section">
+          
+                  <div class="card__labels">
+                      <div class="label label--medium">
+                          <span class="label__text">medium severity</span>
+                      </div>
+                  </div>
+          
+                  <hr/>
+          
+                  <ul class="card__meta">
+                      <li class="card__meta__item">
+                          Package Manager: pip
+                      </li>
+                      <li class="card__meta__item">
+                              Vulnerable module:
+          
+                              django
+                      </li>
+          
+                      <li class="card__meta__item">Introduced through:
+          
+                                  python-pip-app-with-vulns@0.0.0 and django@1.6.1
+          
+                      </li>
+                  </ul>
+          
+                  <hr/>
+          
+          
+                          <h3 class="card__section__title">Detailed paths</h3>
+          
+                      <ul class="card__meta__paths">
+                                  <li>
+                                  <span class="list-paths__item__introduced"><em>Introduced through</em>:
+                                          python-pip-app-with-vulns@0.0.0
+                                           <span class="list-paths__item__arrow">›</span> 
+                                          django@1.6.1
+                                          
+                                  </span>
+          
+                              </li>
+                      </ul><!-- .list-paths -->
+          
+              </div><!-- .card__section -->
+          
+                <hr/>
+                <!-- Overview -->
+                <h2 id="overview">Overview</h2>
+          <p><a href="https://pypi.python.org/pypi/Django"><code>Django</code></a> is a high-level Python Web framework that encourages rapid development and clean, pragmatic design.</p>
+          <p>Affected versions of this package are vulnerable to Arbitrary Code Execution attacks. The <code>django.core.urlresolvers.reverse</code> function allows remote attackers to import and execute arbitrary Python modules by leveraging a view that constructs URLs using user input and a &quot;dotted Python path.&quot;</p>
+          <h2 id="remediation">Remediation</h2>
+          <p>Upgrade to versions <code>1.7b2</code>, <code>1.6.3</code>, <code>1.5.6</code>, <code>1.4.11</code> or greater.</p>
+          <h2 id="references">References</h2>
+          <ul>
+          <li><a href="https://www.djangoproject.com/weblog/2014/apr/21/security/">Django Vulnerability Description</a></li>
+          <li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0472">Redhat Bugzilla</a></li>
+          <li><a href="https://rhn.redhat.com/errata/RHSA-2014-0456.html">Redhat Vulnerability Advisory</a></li>
+          </ul>
+          
+                <hr/>
+          
+              <div class="cta card__cta">
+                  <p><a href="https://snyk.io/vuln/SNYK-PYTHON-DJANGO-40025">More about this vulnerability</a></p>
+              </div>
+          
+          </div><!-- .card -->
+      </section><!-- end unresolved -->
 
       <div class="layout-container" style="padding-top: 35px;">
           <div class="cards--vuln filter--patch filter--ignore">

--- a/test/fixtures/test-report-remediation-missing-patch.json
+++ b/test/fixtures/test-report-remediation-missing-patch.json
@@ -1,0 +1,1373 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:U/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-04-28T14:32:13.683154Z",
+      "credit": [
+        "posix"
+      ],
+      "cvssScore": 6.3,
+      "description": "## Overview\n\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe function `zipObjectDeep` can be tricked into adding or modifying properties of the Object prototype. These properties will be present on all objects.\r\n\r\n## PoC\r\n```\r\nconst _ = require('lodash');\r\n_.zipObjectDeep(['__proto__.z'],[123])\r\nconsole.log(z) // 123\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nThere is no fixed version for `lodash`.\n\n\n## References\n\n- [HackerOne Report](https://hackerone.com/reports/712065)\n",
+      "disclosureTime": "2020-04-27T22:14:18Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-LODASH-567746",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2020-04-30T11:37:44.302231Z",
+      "moduleName": "lodash",
+      "packageManager": "npm",
+      "packageName": "lodash",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:SNYK-JS-LODASH-567746:0",
+          "modificationTime": "2020-04-30T14:28:46.729327Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/lodash/20200430/lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+          ],
+          "version": ">=4.14.2"
+        }
+      ],
+      "publicationTime": "2020-04-28T14:59:14Z",
+      "references": [
+        {
+          "title": "HackerOne Report",
+          "url": "https://hackerone.com/reports/712065"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "*"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "npm-two-vuln-deps@1.0.0",
+        "twilio@2.11.1",
+        "request@2.74.0",
+        "form-data@1.0.1",
+        "async@2.6.3",
+        "lodash@4.17.15"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": true,
+      "name": "lodash",
+      "version": "4.17.15"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-03-11T08:25:47.093051Z",
+      "credit": [
+        "Snyk Security Team"
+      ],
+      "cvssScore": 5.6,
+      "description": "## Overview\n\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n\n\n## References\n\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+      "disclosureTime": "2020-03-10T08:22:24Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "0.2.1",
+        "1.2.3"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "index.js",
+            "functionName": "setKey"
+          },
+          "version": [
+            "<0.2.1",
+            ">=1.0.0 <1.1.1"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "index.js",
+            "functionName": "module.exports.setKey"
+          },
+          "version": [
+            "<0.2.1",
+            ">=1.1.1 <1.2.3"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "index.js",
+            "functionName": "setKey"
+          },
+          "version": [
+            "<0.2.1",
+            ">=1.0.0 <1.1.1"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "index.js",
+            "functionName": "module.exports.setKey"
+          },
+          "version": [
+            "<0.2.1",
+            ">=1.1.1 <1.2.3"
+          ]
+        }
+      ],
+      "id": "SNYK-JS-MINIMIST-559764",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-7598"
+        ],
+        "CWE": [
+          "CWE-400"
+        ],
+        "GHSA": [
+          "GHSA-vh95-rmgr-6w4m"
+        ],
+        "NSP": [
+          1179
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2020-04-29T17:51:37.546682Z",
+      "moduleName": "minimist",
+      "packageManager": "npm",
+      "packageName": "minimist",
+      "patches": [],
+      "publicationTime": "2020-03-11T08:22:19Z",
+      "references": [
+        {
+          "title": "Command Injection PoC",
+          "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+        },
+        {
+          "title": "GitHub Fix Commit #1",
+          "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+        },
+        {
+          "title": "GitHub Fix Commit #2",
+          "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+        },
+        {
+          "title": "Snyk Research Blog",
+          "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<0.2.1",
+          ">=1.0.0 <1.2.3"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "npm-two-vuln-deps@1.0.0",
+        "sharp@0.17.3",
+        "tar@2.2.2",
+        "fstream@1.0.12",
+        "mkdirp@0.5.1",
+        "minimist@0.0.8"
+      ],
+      "upgradePath": [
+        false,
+        "sharp@0.17.3",
+        "tar@2.2.2",
+        "fstream@1.0.12",
+        "mkdirp@0.5.2",
+        "minimist@1.2.5"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "minimist",
+      "version": "0.0.8"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [
+        "SNYK-JS-HOEK-12061"
+      ],
+      "creationTime": "2018-02-12T22:28:27.612000Z",
+      "credit": [
+        "Olivier Arteau (HoLyVieR)"
+      ],
+      "cvssScore": 6.3,
+      "description": "## Overview\n\n[hoek](https://github.com/hapijs/hoek) is a Utility methods for the hapi ecosystem.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar Hoek = require('hoek');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\nHoek.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `hoek` to version 4.2.1, 5.0.3 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee)\n\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df)\n\n- [GitHub Issue](https://github.com/hapijs/hoek/issues/230)\n\n- [GitHub PR](https://github.com/hapijs/hoek/pull/227)\n\n- [HackerOne Report](https://hackerone.com/reports/310439)\n\n- [NPM Security Advisory](http://npmjs.com/advisories/566)\n",
+      "disclosureTime": "2018-02-12T22:28:27Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "4.2.1",
+        "5.0.3"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/hoek.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">0.0.18 <4.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">=5.0.0 <5.0.3"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "lib/hoek.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">0.0.18 <4.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">=5.0.0 <5.0.3"
+          ]
+        }
+      ],
+      "id": "npm:hoek:20180212",
+      "identifiers": {
+        "ALTERNATIVE": [
+          "SNYK-JS-HOEK-12061"
+        ],
+        "CVE": [
+          "CVE-2018-3728"
+        ],
+        "CWE": [
+          "CWE-400"
+        ],
+        "NSP": [
+          566
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-05-21T07:48:56.121075Z",
+      "moduleName": "hoek",
+      "packageManager": "npm",
+      "packageName": "hoek",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:npm:hoek:20180212:0",
+          "modificationTime": "2019-12-03T11:40:45.879582Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+          ],
+          "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+        },
+        {
+          "comments": [],
+          "id": "patch:npm:hoek:20180212:1",
+          "modificationTime": "2019-12-03T11:40:45.880722Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+          ],
+          "version": ">=2.0.0 <3.0.0"
+        }
+      ],
+      "publicationTime": "2018-02-14T13:22:50Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/hapijs/hoek/issues/230"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/hapijs/hoek/pull/227"
+        },
+        {
+          "title": "HackerOne Report",
+          "url": "https://hackerone.com/reports/310439"
+        },
+        {
+          "title": "NPM Security Advisory",
+          "url": "http://npmjs.com/advisories/566"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<4.2.1",
+          ">=5.0.0 <5.0.3"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "npm-two-vuln-deps@1.0.0",
+        "twilio@2.11.1",
+        "request@2.74.0",
+        "hawk@3.1.3",
+        "hoek@2.16.3"
+      ],
+      "upgradePath": [
+        false,
+        "twilio@3.9.0",
+        "request@2.83.0",
+        "hawk@6.0.2",
+        "hoek@4.2.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": true,
+      "name": "hoek",
+      "version": "2.16.3"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [
+        "SNYK-JS-HOEK-12061"
+      ],
+      "creationTime": "2018-02-12T22:28:27.612000Z",
+      "credit": [
+        "Olivier Arteau (HoLyVieR)"
+      ],
+      "cvssScore": 6.3,
+      "description": "## Overview\n\n[hoek](https://github.com/hapijs/hoek) is a Utility methods for the hapi ecosystem.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar Hoek = require('hoek');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\nHoek.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `hoek` to version 4.2.1, 5.0.3 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee)\n\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df)\n\n- [GitHub Issue](https://github.com/hapijs/hoek/issues/230)\n\n- [GitHub PR](https://github.com/hapijs/hoek/pull/227)\n\n- [HackerOne Report](https://hackerone.com/reports/310439)\n\n- [NPM Security Advisory](http://npmjs.com/advisories/566)\n",
+      "disclosureTime": "2018-02-12T22:28:27Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "4.2.1",
+        "5.0.3"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/hoek.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">0.0.18 <4.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">=5.0.0 <5.0.3"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "lib/hoek.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">0.0.18 <4.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">=5.0.0 <5.0.3"
+          ]
+        }
+      ],
+      "id": "npm:hoek:20180212",
+      "identifiers": {
+        "ALTERNATIVE": [
+          "SNYK-JS-HOEK-12061"
+        ],
+        "CVE": [
+          "CVE-2018-3728"
+        ],
+        "CWE": [
+          "CWE-400"
+        ],
+        "NSP": [
+          566
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-05-21T07:48:56.121075Z",
+      "moduleName": "hoek",
+      "packageManager": "npm",
+      "packageName": "hoek",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:npm:hoek:20180212:0",
+          "modificationTime": "2019-12-03T11:40:45.879582Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+          ],
+          "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+        },
+        {
+          "comments": [],
+          "id": "patch:npm:hoek:20180212:1",
+          "modificationTime": "2019-12-03T11:40:45.880722Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+          ],
+          "version": ">=2.0.0 <3.0.0"
+        }
+      ],
+      "publicationTime": "2018-02-14T13:22:50Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/hapijs/hoek/issues/230"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/hapijs/hoek/pull/227"
+        },
+        {
+          "title": "HackerOne Report",
+          "url": "https://hackerone.com/reports/310439"
+        },
+        {
+          "title": "NPM Security Advisory",
+          "url": "http://npmjs.com/advisories/566"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<4.2.1",
+          ">=5.0.0 <5.0.3"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "npm-two-vuln-deps@1.0.0",
+        "twilio@2.11.1",
+        "request@2.74.0",
+        "hawk@3.1.3",
+        "boom@2.10.1",
+        "hoek@2.16.3"
+      ],
+      "upgradePath": [
+        false,
+        "twilio@3.9.0",
+        "request@2.83.0",
+        "hawk@6.0.2",
+        "boom@4.0.0",
+        "hoek@4.2.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": true,
+      "name": "hoek",
+      "version": "2.16.3"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [
+        "SNYK-JS-HOEK-12061"
+      ],
+      "creationTime": "2018-02-12T22:28:27.612000Z",
+      "credit": [
+        "Olivier Arteau (HoLyVieR)"
+      ],
+      "cvssScore": 6.3,
+      "description": "## Overview\n\n[hoek](https://github.com/hapijs/hoek) is a Utility methods for the hapi ecosystem.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar Hoek = require('hoek');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\nHoek.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `hoek` to version 4.2.1, 5.0.3 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee)\n\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df)\n\n- [GitHub Issue](https://github.com/hapijs/hoek/issues/230)\n\n- [GitHub PR](https://github.com/hapijs/hoek/pull/227)\n\n- [HackerOne Report](https://hackerone.com/reports/310439)\n\n- [NPM Security Advisory](http://npmjs.com/advisories/566)\n",
+      "disclosureTime": "2018-02-12T22:28:27Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "4.2.1",
+        "5.0.3"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/hoek.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">0.0.18 <4.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">=5.0.0 <5.0.3"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "lib/hoek.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">0.0.18 <4.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">=5.0.0 <5.0.3"
+          ]
+        }
+      ],
+      "id": "npm:hoek:20180212",
+      "identifiers": {
+        "ALTERNATIVE": [
+          "SNYK-JS-HOEK-12061"
+        ],
+        "CVE": [
+          "CVE-2018-3728"
+        ],
+        "CWE": [
+          "CWE-400"
+        ],
+        "NSP": [
+          566
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-05-21T07:48:56.121075Z",
+      "moduleName": "hoek",
+      "packageManager": "npm",
+      "packageName": "hoek",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:npm:hoek:20180212:0",
+          "modificationTime": "2019-12-03T11:40:45.879582Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+          ],
+          "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+        },
+        {
+          "comments": [],
+          "id": "patch:npm:hoek:20180212:1",
+          "modificationTime": "2019-12-03T11:40:45.880722Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+          ],
+          "version": ">=2.0.0 <3.0.0"
+        }
+      ],
+      "publicationTime": "2018-02-14T13:22:50Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/hapijs/hoek/issues/230"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/hapijs/hoek/pull/227"
+        },
+        {
+          "title": "HackerOne Report",
+          "url": "https://hackerone.com/reports/310439"
+        },
+        {
+          "title": "NPM Security Advisory",
+          "url": "http://npmjs.com/advisories/566"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<4.2.1",
+          ">=5.0.0 <5.0.3"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "npm-two-vuln-deps@1.0.0",
+        "twilio@2.11.1",
+        "request@2.74.0",
+        "hawk@3.1.3",
+        "sntp@1.0.9",
+        "hoek@2.16.3"
+      ],
+      "upgradePath": [
+        false,
+        "twilio@3.9.0",
+        "request@2.83.0",
+        "hawk@6.0.2",
+        "sntp@2.0.1",
+        "hoek@4.2.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": true,
+      "name": "hoek",
+      "version": "2.16.3"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [
+        "SNYK-JS-HOEK-12061"
+      ],
+      "creationTime": "2018-02-12T22:28:27.612000Z",
+      "credit": [
+        "Olivier Arteau (HoLyVieR)"
+      ],
+      "cvssScore": 6.3,
+      "description": "## Overview\n\n[hoek](https://github.com/hapijs/hoek) is a Utility methods for the hapi ecosystem.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar Hoek = require('hoek');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\nHoek.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `hoek` to version 4.2.1, 5.0.3 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee)\n\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df)\n\n- [GitHub Issue](https://github.com/hapijs/hoek/issues/230)\n\n- [GitHub PR](https://github.com/hapijs/hoek/pull/227)\n\n- [HackerOne Report](https://hackerone.com/reports/310439)\n\n- [NPM Security Advisory](http://npmjs.com/advisories/566)\n",
+      "disclosureTime": "2018-02-12T22:28:27Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "4.2.1",
+        "5.0.3"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/hoek.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">0.0.18 <4.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">=5.0.0 <5.0.3"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "lib/hoek.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">0.0.18 <4.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "lib/index.js",
+            "functionName": "exports.merge"
+          },
+          "version": [
+            ">=5.0.0 <5.0.3"
+          ]
+        }
+      ],
+      "id": "npm:hoek:20180212",
+      "identifiers": {
+        "ALTERNATIVE": [
+          "SNYK-JS-HOEK-12061"
+        ],
+        "CVE": [
+          "CVE-2018-3728"
+        ],
+        "CWE": [
+          "CWE-400"
+        ],
+        "NSP": [
+          566
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-05-21T07:48:56.121075Z",
+      "moduleName": "hoek",
+      "packageManager": "npm",
+      "packageName": "hoek",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:npm:hoek:20180212:0",
+          "modificationTime": "2019-12-03T11:40:45.879582Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+          ],
+          "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+        },
+        {
+          "comments": [],
+          "id": "patch:npm:hoek:20180212:1",
+          "modificationTime": "2019-12-03T11:40:45.880722Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+          ],
+          "version": ">=2.0.0 <3.0.0"
+        }
+      ],
+      "publicationTime": "2018-02-14T13:22:50Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/hapijs/hoek/issues/230"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/hapijs/hoek/pull/227"
+        },
+        {
+          "title": "HackerOne Report",
+          "url": "https://hackerone.com/reports/310439"
+        },
+        {
+          "title": "NPM Security Advisory",
+          "url": "http://npmjs.com/advisories/566"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<4.2.1",
+          ">=5.0.0 <5.0.3"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "npm-two-vuln-deps@1.0.0",
+        "twilio@2.11.1",
+        "request@2.74.0",
+        "hawk@3.1.3",
+        "cryptiles@2.0.5",
+        "boom@2.10.1",
+        "hoek@2.16.3"
+      ],
+      "upgradePath": [
+        false,
+        "twilio@3.9.0",
+        "request@2.83.0",
+        "hawk@6.0.2",
+        "cryptiles@3.0.0",
+        "boom@3.1.3",
+        "hoek@4.2.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": true,
+      "name": "hoek",
+      "version": "2.16.3"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+      "alternativeIds": [
+        "SNYK-JS-MS-10509"
+      ],
+      "creationTime": "2017-04-12T10:02:45.497000Z",
+      "credit": [
+        "Snyk Security Research Team"
+      ],
+      "cvssScore": 3.7,
+      "description": "## Overview\r\n[`ms`](https://www.npmjs.com/package/ms) is a tiny millisecond conversion utility.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) due to an incomplete fix for previously reported vulnerability [npm:ms:20151024](https://snyk.io/vuln/npm:ms:20151024). The fix limited the length of accepted input string to 10,000 characters, and turned to be insufficient making it possible to block the event loop for 0.3 seconds (on a typical laptop) with a specially crafted string passed to `ms()` function.\r\n\r\n*Proof of concept*\r\n```js\r\nms = require('ms');\r\nms('1'.repeat(9998) + 'Q') // Takes about ~0.3s\r\n```\r\n\r\n**Note:** Snyk's patch for this vulnerability limits input length to 100 characters. This new limit was deemed to be a breaking change by the author.\r\nBased on user feedback, we believe the risk of breakage is _very_ low, while the value to your security is much greater, and therefore opted to still capture this change in a patch for earlier versions as well.  Whenever patching security issues, we always suggest to run tests on your code to validate that nothing has been broken.\r\n\r\nFor more information on `Regular Expression Denial of Service (ReDoS)` attacks, go to our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\r\n\r\n## Disclosure Timeline\r\n- Feb 9th, 2017 - Reported the issue to package owner.\r\n- Feb 11th, 2017 - Issue acknowledged by package owner.\r\n- April 12th, 2017 - Fix PR opened by Snyk Security Team.\r\n- May 15th, 2017 - Vulnerability published.\r\n- May 16th, 2017 - Issue fixed and version `2.0.0` released.\r\n- May 21th, 2017 - Patches released for versions `>=0.7.1, <=1.0.0`.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `ms` to version 2.0.0 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/zeit/ms/pull/89)\r\n- [GitHub Commit](https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef)",
+      "disclosureTime": "2017-04-11T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.0.0"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "index.js",
+            "functionName": "parse"
+          },
+          "version": [
+            ">=0.7.3 <2.0.0"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "index.js",
+            "functionName": "parse"
+          },
+          "version": [
+            ">=0.7.3 <2.0.0"
+          ]
+        }
+      ],
+      "id": "npm:ms:20170412",
+      "identifiers": {
+        "ALTERNATIVE": [
+          "SNYK-JS-MS-10509"
+        ],
+        "CVE": [],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-05-23T07:50:28.604870Z",
+      "moduleName": "ms",
+      "packageManager": "npm",
+      "packageName": "ms",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:npm:ms:20170412:0",
+          "modificationTime": "2019-12-03T11:40:45.863964Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/ms/20170412/ms_100.patch"
+          ],
+          "version": "=1.0.0"
+        },
+        {
+          "comments": [],
+          "id": "patch:npm:ms:20170412:1",
+          "modificationTime": "2019-12-03T11:40:45.865081Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/ms/20170412/ms_072-073.patch"
+          ],
+          "version": "=0.7.2 || =0.7.3"
+        },
+        {
+          "comments": [],
+          "id": "patch:npm:ms:20170412:2",
+          "modificationTime": "2019-12-03T11:40:45.866206Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/ms/20170412/ms_071.patch"
+          ],
+          "version": "=0.7.1"
+        }
+      ],
+      "publicationTime": "2017-05-15T06:02:45Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/zeit/ms/pull/89"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          ">=0.7.1 <2.0.0"
+        ]
+      },
+      "severity": "low",
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "from": [
+        "npm-two-vuln-deps@1.0.0",
+        "twilio@2.11.1",
+        "jsonwebtoken@5.4.1",
+        "ms@0.7.3"
+      ],
+      "upgradePath": [
+        false,
+        "twilio@3.5.0",
+        "jsonwebtoken@7.4.1",
+        "ms@2.0.0"
+      ],
+      "isUpgradable": true,
+      "isPatchable": true,
+      "name": "ms",
+      "version": "0.7.3"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N/E:P/RL:O/RC:C",
+      "alternativeIds": [
+        "SNYK-JS-TUNNELAGENT-10672"
+      ],
+      "creationTime": "2017-07-05T07:23:57.738000Z",
+      "credit": [
+        "ChALkeR"
+      ],
+      "cvssScore": 5.1,
+      "description": "## Overview\r\n[`tunnel-agent`](https://www.npmjs.com/package/tunnel-agent) is HTTP proxy tunneling agent. Affected versions of the package are vulnerable to Uninitialized Memory Exposure. \r\n\r\nA possible memory disclosure vulnerability exists when a value of type `number` is used to set the _proxy.auth_ option of a request `request` and results in a possible uninitialized memory exposures in the request body.\r\n\r\nThis is a result of unobstructed use of the `Buffer` constructor, whose [insecure default constructor increases the odds of memory leakage](https://snyk.io/blog/exploiting-buffer/).\r\n\r\n## Details\r\nConstructing a `Buffer` class with integer `N` creates a `Buffer` of length `N` with raw (not \"zero-ed\") memory.\r\n\r\nIn the following example, the first call would allocate 100 bytes of memory, while the second example will allocate the memory needed for the string \"100\":\r\n```js\r\n// uninitialized Buffer of length 100\r\nx = new Buffer(100);\r\n// initialized Buffer with value of '100'\r\nx = new Buffer('100');\r\n```\r\n\r\n`tunnel-agent`'s `request` construction uses the default `Buffer` constructor as-is, making it easy to append uninitialized memory to an existing list. If the value of the buffer list is exposed to users, it may expose raw server side memory, potentially holding secrets, private data and code. This is a similar vulnerability to the infamous [`Heartbleed`](http://heartbleed.com/) flaw in OpenSSL.\r\n\r\n#### Proof of concept by ChALkeR\r\n```js\r\nrequire('request')({\r\n  method: 'GET',\r\n  uri: 'http://www.example.com',\r\n  tunnel: true,\r\n  proxy:{\r\n      protocol: 'http:',\r\n      host:\"127.0.0.1\",\r\n      port:8080,\r\n      auth:80\r\n  }\r\n});\r\n```\r\n\r\nYou can read more about the insecure `Buffer` behavior [on our blog](https://snyk.io/blog/exploiting-buffer/).\r\n\r\nSimilar vulnerabilities were discovered in [request](https://snyk.io/vuln/npm:request:20160119), [mongoose](https://snyk.io/vuln/npm:mongoose:20160116), [ws](https://snyk.io/vuln/npm:ws:20160104) and [sequelize](https://snyk.io/vuln/npm:sequelize:20160115).\r\n\r\n## Remediation\r\nUpgrade `tunnel-agent` to version 0.6.0 or higher.\r\n**Note** This is vulnerable only for Node <=4\n\n## References\n- [GitHub Commit](https://github.com/request/tunnel-agent/commit/9ca95ec7219daface8a6fc2674000653de0922c0)\n- [PoC by ChALkeR](https://gist.github.com/ChALkeR/fd6b2c445834244e7d440a043f9d2ff4)\n",
+      "disclosureTime": "2017-03-04T22:00:00Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "0.6.0"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "index.js",
+            "functionName": "TunnelingAgent.prototype.createSocket"
+          },
+          "version": [
+            "<0.6.0"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "index.js",
+            "functionName": "TunnelingAgent.prototype.createSocket"
+          },
+          "version": [
+            "<0.6.0"
+          ]
+        }
+      ],
+      "id": "npm:tunnel-agent:20170305",
+      "identifiers": {
+        "ALTERNATIVE": [
+          "SNYK-JS-TUNNELAGENT-10672"
+        ],
+        "CVE": [],
+        "CWE": [
+          "CWE-201"
+        ],
+        "GHSA": [
+          "GHSA-xc7v-wxcw-j472"
+        ],
+        "NSP": [
+          598
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-12-02T14:38:58.879097Z",
+      "moduleName": "tunnel-agent",
+      "packageManager": "npm",
+      "packageName": "tunnel-agent",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:npm:tunnel-agent:20170305:0",
+          "modificationTime": "2019-12-03T11:40:45.868281Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/tunnel-agent/20170305/tunnel-agent_20170305_0_0_9ca95ec7219daface8a6fc2674000653de0922c0.patch"
+          ],
+          "version": "=0.4.3 || =0.5.0"
+        }
+      ],
+      "publicationTime": "2017-07-05T14:05:50Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/request/tunnel-agent/commit/9ca95ec7219daface8a6fc2674000653de0922c0"
+        },
+        {
+          "title": "PoC by ChALkeR",
+          "url": "https://gist.github.com/ChALkeR/fd6b2c445834244e7d440a043f9d2ff4"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<0.6.0"
+        ]
+      },
+      "severity": "medium",
+      "title": "Uninitialized Memory Exposure",
+      "from": [
+        "npm-two-vuln-deps@1.0.0",
+        "twilio@2.11.1",
+        "request@2.74.0",
+        "tunnel-agent@0.4.3"
+      ],
+      "upgradePath": [
+        false,
+        "twilio@3.0.0",
+        "request@2.81.0",
+        "tunnel-agent@0.6.0"
+      ],
+      "isUpgradable": true,
+      "isPatchable": true,
+      "name": "tunnel-agent",
+      "version": "0.4.3"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 135,
+  "org": "ekbsnyk",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "npm",
+  "ignoreSettings": null,
+  "summary": "8 vulnerable dependency paths",
+  "remediation": {
+    "unresolved": [
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-03-11T08:25:47.093051Z",
+        "credit": [
+          "Snyk Security Team"
+        ],
+        "cvssScore": 5.6,
+        "description": "## Overview\n\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n\n\n## References\n\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+        "disclosureTime": "2020-03-10T08:22:24Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "0.2.1",
+          "1.2.3"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "index.js",
+              "functionName": "setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.0.0 <1.1.1"
+            ]
+          },
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "index.js",
+              "functionName": "module.exports.setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.1.1 <1.2.3"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.0.0 <1.1.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.1.1 <1.2.3"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-MINIMIST-559764",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-7598"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-vh95-rmgr-6w4m"
+          ],
+          "NSP": [
+            1179
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2020-04-29T17:51:37.546682Z",
+        "moduleName": "minimist",
+        "packageManager": "npm",
+        "packageName": "minimist",
+        "patches": [],
+        "publicationTime": "2020-03-11T08:22:19Z",
+        "references": [
+          {
+            "title": "Command Injection PoC",
+            "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+          },
+          {
+            "title": "GitHub Fix Commit #1",
+            "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+          },
+          {
+            "title": "GitHub Fix Commit #2",
+            "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+          },
+          {
+            "title": "Snyk Research Blog",
+            "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.2.1",
+            ">=1.0.0 <1.2.3"
+          ]
+        },
+        "severity": "medium",
+        "title": "Prototype Pollution",
+        "from": [
+          "npm-two-vuln-deps@1.0.0",
+          "sharp@0.17.3",
+          "tar@2.2.2",
+          "fstream@1.0.12",
+          "mkdirp@0.5.1",
+          "minimist@0.0.8"
+        ],
+        "upgradePath": [
+          false,
+          "sharp@0.17.3",
+          "tar@2.2.2",
+          "fstream@1.0.12",
+          "mkdirp@0.5.2",
+          "minimist@1.2.5"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "minimist",
+        "version": "0.0.8"
+      }
+    ],
+    "upgrade": {
+      "twilio@2.11.1": {
+        "upgradeTo": "twilio@3.9.0",
+        "upgrades": [
+          "hoek@2.16.3",
+          "ms@0.7.3",
+          "tunnel-agent@0.4.3"
+        ],
+        "vulns": [
+          "npm:hoek:20180212",
+          "npm:ms:20170412",
+          "npm:tunnel-agent:20170305"
+        ]
+      }
+    },
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 5,
+  "projectName": "npm-two-vuln-deps",
+  "displayTargetFile": "package-lock.json",
+  "path": "/path/to/npm-lockfile-with-vulns"
+}

--- a/test/remediation.spec.ts
+++ b/test/remediation.spec.ts
@@ -43,6 +43,16 @@ describe('normalizeRemediationChanges', () => {
     });
   });
 
+  it('adds empty defaults when remediation has no sub-fields', () => {
+    expect(normalizeRemediationChanges({})).toEqual({
+      unresolved: [],
+      upgrade: {},
+      patch: {},
+      ignore: {},
+      pin: {},
+    });
+  });
+
   it('leaves complete remediation objects unchanged', () => {
     const remediation = {
       upgrade: {},
@@ -88,6 +98,25 @@ describe('SnykToHtml remediation normalization', () => {
         unresolved: [],
         ignore: {},
       },
+    });
+
+    SnykToHtml.run(reportPath, true, remediationTemplate, false, (report) => {
+      try {
+        expect(report).toContain('remediation-card');
+        done();
+      } catch (error: any) {
+        done(error);
+      } finally {
+        fs.unlinkSync(reportPath);
+      }
+    });
+  });
+
+  it('generates actionable remediation when remediation is an empty object', (done) => {
+    const reportPath = writeTempReport({
+      ok: false,
+      vulnerabilities: [],
+      remediation: {},
     });
 
     SnykToHtml.run(reportPath, true, remediationTemplate, false, (report) => {

--- a/test/remediation.spec.ts
+++ b/test/remediation.spec.ts
@@ -26,7 +26,19 @@ describe('normalizeRemediationChanges', () => {
     expect(normalizeRemediationChanges(undefined)).toBeUndefined();
   });
 
-  it('adds empty defaults for missing sub-fields', () => {
+  it('leaves remediation unchanged when all sub-fields are present', () => {
+    const remediation = {
+      upgrade: { 'lodash@4.17.15': { upgradeTo: 'lodash@4.17.21' } },
+      pin: { 'pkg@1.0.0': { upgradeTo: 'pkg@1.0.1', vulns: [] } },
+      patch: { 'SNYK-123': { paths: [] } },
+      ignore: { 'SNYK-123': [] },
+      unresolved: [{ id: 'SNYK-456' }],
+    };
+
+    expect(normalizeRemediationChanges(remediation)).toEqual(remediation);
+  });
+
+  it('adds empty defaults when remediation contains only some sub-fields', () => {
     const remediation = {
       upgrade: { 'lodash@4.17.15': { upgradeTo: 'lodash@4.17.21' } },
       pin: {},
@@ -43,7 +55,7 @@ describe('normalizeRemediationChanges', () => {
     });
   });
 
-  it('adds empty defaults when remediation has no sub-fields', () => {
+  it('adds empty defaults when remediation contains none of the sub-fields', () => {
     expect(normalizeRemediationChanges({})).toEqual({
       unresolved: [],
       upgrade: {},
@@ -52,21 +64,26 @@ describe('normalizeRemediationChanges', () => {
       pin: {},
     });
   });
-
-  it('leaves complete remediation objects unchanged', () => {
-    const remediation = {
-      upgrade: {},
-      pin: {},
-      patch: { 'SNYK-123': { paths: [] } },
-      ignore: { 'SNYK-123': [] },
-      unresolved: [{ id: 'SNYK-123' }],
-    };
-
-    expect(normalizeRemediationChanges(remediation)).toEqual(remediation);
-  });
 });
 
 describe('SnykToHtml remediation normalization', () => {
+  it('generates actionable remediation when all sub-fields are present', (done) => {
+    SnykToHtml.run(
+      path.join(__dirname, 'fixtures', 'test-report-with-remediation.json'),
+      true,
+      remediationTemplate,
+      false,
+      (report) => {
+        try {
+          expect(report).toContain('remediation-card');
+          done();
+        } catch (error: any) {
+          done(error);
+        }
+      },
+    );
+  });
+
   it('generates actionable remediation when patch is omitted', (done) => {
     SnykToHtml.run(
       path.join(
@@ -88,7 +105,7 @@ describe('SnykToHtml remediation normalization', () => {
     );
   });
 
-  it('generates actionable remediation for CLI-shaped JSON missing patch', (done) => {
+  it('generates actionable remediation when only some sub-fields are present', (done) => {
     const reportPath = writeTempReport({
       ok: false,
       vulnerabilities: [],
@@ -112,7 +129,7 @@ describe('SnykToHtml remediation normalization', () => {
     });
   });
 
-  it('generates actionable remediation when remediation is an empty object', (done) => {
+  it('generates actionable remediation when none of the sub-fields are present', (done) => {
     const reportPath = writeTempReport({
       ok: false,
       vulnerabilities: [],

--- a/test/remediation.spec.ts
+++ b/test/remediation.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SnykToHtml } from '../src/lib/snyk-to-html';
+import { normalizeRemediationChanges } from '../src/lib/vuln';
+
+const remediationTemplate = path.join(
+  __dirname,
+  '..',
+  'template',
+  'remediation-report.hbs',
+);
+
+function writeTempReport(report: object): string {
+  const filePath = path.join(
+    os.tmpdir(),
+    `snyk-to-html-remediation-${Date.now()}-${Math.random()}.json`,
+  );
+  fs.writeFileSync(filePath, JSON.stringify(report));
+  return filePath;
+}
+
+describe('normalizeRemediationChanges', () => {
+  it('returns undefined when remediation is absent', () => {
+    expect(normalizeRemediationChanges(undefined)).toBeUndefined();
+  });
+
+  it('adds empty defaults for missing sub-fields', () => {
+    const remediation = {
+      upgrade: { 'lodash@4.17.15': { upgradeTo: 'lodash@4.17.21' } },
+      pin: {},
+      unresolved: [],
+      ignore: {},
+    };
+
+    expect(normalizeRemediationChanges(remediation)).toEqual({
+      upgrade: remediation.upgrade,
+      pin: {},
+      patch: {},
+      ignore: {},
+      unresolved: [],
+    });
+  });
+
+  it('leaves complete remediation objects unchanged', () => {
+    const remediation = {
+      upgrade: {},
+      pin: {},
+      patch: { 'SNYK-123': { paths: [] } },
+      ignore: { 'SNYK-123': [] },
+      unresolved: [{ id: 'SNYK-123' }],
+    };
+
+    expect(normalizeRemediationChanges(remediation)).toEqual(remediation);
+  });
+});
+
+describe('SnykToHtml remediation normalization', () => {
+  it('generates actionable remediation when patch is omitted', (done) => {
+    SnykToHtml.run(
+      path.join(
+        __dirname,
+        'fixtures',
+        'test-report-remediation-missing-patch.json',
+      ),
+      true,
+      remediationTemplate,
+      false,
+      (report) => {
+        try {
+          expect(report).toContain('remediation-card');
+          done();
+        } catch (error: any) {
+          done(error);
+        }
+      },
+    );
+  });
+
+  it('generates actionable remediation for CLI-shaped JSON missing patch', (done) => {
+    const reportPath = writeTempReport({
+      ok: false,
+      vulnerabilities: [],
+      remediation: {
+        upgrade: {},
+        pin: {},
+        unresolved: [],
+        ignore: {},
+      },
+    });
+
+    SnykToHtml.run(reportPath, true, remediationTemplate, false, (report) => {
+      try {
+        expect(report).toContain('remediation-card');
+        done();
+      } catch (error: any) {
+        done(error);
+      } finally {
+        fs.unlinkSync(reportPath);
+      }
+    });
+  });
+});

--- a/test/snyk-from-commandline.spec.ts
+++ b/test/snyk-from-commandline.spec.ts
@@ -53,6 +53,7 @@ describe('test calling snyk-to-html from command line', () => {
     expect(cleanedReport).toContain(
       '<body class="test-remediation-section-projects">',
     );
+    expect(cleanedReport).toContain('Issues with no direct upgrade or patch');
     expect(cleanedReport).toMatchSnapshot();
   });
 
@@ -87,6 +88,7 @@ describe('test calling snyk-to-html from command line', () => {
       expect(cleanedReport).toContain(
         "<div class='remediation-card__pane shown test-remediation-pins'",
       );
+      expect(cleanedReport).toContain('Issues with no direct upgrade or patch');
       expect(cleanedReport).toMatchSnapshot();
     },
   );


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commits are squashed and tidy and are suitable to become release notes

### What this does

`Snyk-to-html` errors on jsons that does not include remediation sub-fields when using `--action-remediation`.

Why this happens: `snyk test --json` can emit a remediation object that only includes non-empty keys (e.g. upgrade, pin, unresolved, ignore) and omits patch when there are no patchable issues. With --actionable-remediation (-a), `snyk-to-html` destructures those fields and calls `Object.entries(undefined)` (in `addIssueDataToPatch()` when `patch` is missing) / `Object.keys(undefined)` (in `getUpgrades()` when upgrade or `pin` is missing), which throws a `TypeError: Cannot convert undefined or null to object`.

### Notes for the reviewer

1. Download the example json mentioned in ticket
2. Check that the remediation comes empty
   `jq '.remediation.patch' Snyk_Report.json`
3. Use snyk-to-html to create an html out of the generated json: no errors.
   `npx snyk-to-html -i Snyk_Report.json -o output.html -a -d`
4. Optional: open the generated html
<img width="1704" height="1369" alt="image" src="https://github.com/user-attachments/assets/93af9076-0626-4d7c-80d2-abf933c80e0a" />




### More information

- [CLI-1473](https://snyksec.atlassian.net/browse/CLI-1473)

### Screenshots

- build and test
<img width="884" height="941" alt="image" src="https://github.com/user-attachments/assets/6b2cb821-22d7-4010-bde4-3f6c479fa480" />

- fix in `snyk-to-html`
<img width="1156" height="106" alt="image" src="https://github.com/user-attachments/assets/0559de4c-a25a-4f19-a1fa-21071010523f" />
<img width="1704" height="1369" alt="image" src="https://github.com/user-attachments/assets/aef3aa6e-2e6a-4355-928c-b525809537a9" />



[CLI-1473]: https://snyksec.atlassian.net/browse/CLI-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ