### PR TITLE
fix: detect templates when -a sets default

### DIFF
--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -28,6 +28,15 @@ registerHandlebarsHelpers();
 
 const debug = debugModule('snyk-to-html');
 
+const defaultTemplateNames = ['test-report.hbs', 'remediation-report.hbs'];
+
+function isDefaultTemplate(template: string): boolean {
+  const templateDir = path.join(__dirname, '../../template');
+  return defaultTemplateNames.some(
+    (name) => path.resolve(template) === path.resolve(templateDir, name),
+  );
+}
+
 const defaultRemediationText =
   '## Remediation\nThere is no remediation at the moment';
 
@@ -99,16 +108,14 @@ class SnykToHtml {
       ) {
         // for IaC input we need to change the default template to an IaC specific template
         // at the same time we also want to support the -t / --template flag
-        template =
-          template === path.join(__dirname, '../../template/test-report.hbs')
-            ? path.join(__dirname, '../../template/iac/test-report.hbs')
-            : template;
+        template = isDefaultTemplate(template)
+          ? path.join(__dirname, '../../template/iac/test-report.hbs')
+          : template;
         return processIacData(data, template, summary);
       } else if (data?.runs && data?.runs[0].tool.driver.name === 'SnykCode') {
-        template =
-          template === path.join(__dirname, '../../template/test-report.hbs')
-            ? path.join(__dirname, '../../template/code/test-report.hbs')
-            : template;
+        template = isDefaultTemplate(template)
+          ? path.join(__dirname, '../../template/code/test-report.hbs')
+          : template;
         return processCodeData(data, template, summary);
       } else if (data.docker) {
         return processContainerData(data, remediation, template, summary);

--- a/test/snyk-to-html.spec.ts
+++ b/test/snyk-to-html.spec.ts
@@ -500,43 +500,170 @@ describe('test running SnykToHtml.run', () => {
     );
   });
 
-  it('generates a Code report when default template is remediation-report.hbs', (done) => {
-    SnykToHtml.run(
-      path.join(__dirname, 'fixtures/test-code-openrefine.json'),
-      WITH_REMEDIATION,
-      path.join(__dirname, '..', 'template', 'remediation-report.hbs'),
-      WITHOUT_SUMMARY,
-      (report) => {
-        try {
-          expect(report).toContain('Snyk Code Report');
-          expect(report).toContain(
-            '<h2 class="card__title">Path Traversal</h2>',
-          );
-          done();
-        } catch (error: any) {
-          done(error);
-        }
-      },
-    );
-  });
+  describe('template selection (-a / -t combinations)', () => {
+    const templateDir = path.join(__dirname, '..', 'template');
+    const fixturesDir = path.join(__dirname, 'fixtures');
+    const codeMarker = '<h2 class="card__title">Path Traversal</h2>';
+    const iacMarker =
+      '<h2 class="card__title">App Service allows FTP deployments</h2>';
+    const ossMarker =
+      '<h2 class="card__title">Regular Expression Denial of Service (ReDoS)</h2>';
 
-  it('generates an IaC report when default template is remediation-report.hbs', (done) => {
-    SnykToHtml.run(
-      path.join(__dirname, 'fixtures/iac-test-report.json'),
-      WITH_REMEDIATION,
-      path.join(__dirname, '..', 'template', 'remediation-report.hbs'),
-      WITHOUT_SUMMARY,
-      (report) => {
-        try {
-          expect(report).toContain(
-            '<h2 class="card__title">App Service allows FTP deployments</h2>',
-          );
-          done();
-        } catch (error: any) {
-          done(error);
-        }
+    it.each([
+      {
+        scan: 'Code',
+        flags: 'no -a, no -t (default test-report.hbs)',
+        fixture: 'test-code-openrefine.json',
+        remediation: false,
+        template: path.join(templateDir, 'test-report.hbs'),
+        expectContains: ['Snyk Code Report', codeMarker],
       },
-    );
+      {
+        scan: 'Code',
+        flags: 'only -a (default remediation-report.hbs)',
+        fixture: 'test-code-openrefine.json',
+        remediation: true,
+        template: path.join(templateDir, 'remediation-report.hbs'),
+        expectContains: ['Snyk Code Report', codeMarker],
+      },
+      {
+        scan: 'Code',
+        flags: 'only -t (explicit code template)',
+        fixture: 'test-code-openrefine.json',
+        remediation: false,
+        template: path.join(templateDir, 'code', 'test-report.hbs'),
+        expectContains: ['Snyk Code Report', codeMarker],
+      },
+      {
+        scan: 'Code',
+        flags: '-a and -t (explicit code template)',
+        fixture: 'test-code-openrefine.json',
+        remediation: true,
+        template: path.join(templateDir, 'code', 'test-report.hbs'),
+        expectContains: ['Snyk Code Report', codeMarker],
+      },
+      {
+        scan: 'Code',
+        flags: 'only -t (custom non-code template)',
+        fixture: 'test-code-openrefine.json',
+        remediation: false,
+        template: path.join(templateDir, 'test-cve-report.hbs'),
+        rejects: true,
+      },
+      {
+        scan: 'IaC',
+        flags: 'no -a, no -t (default test-report.hbs)',
+        fixture: 'iac-test-report.json',
+        remediation: false,
+        template: path.join(templateDir, 'test-report.hbs'),
+        expectContains: [iacMarker],
+      },
+      {
+        scan: 'IaC',
+        flags: 'only -a (default remediation-report.hbs)',
+        fixture: 'iac-test-report.json',
+        remediation: true,
+        template: path.join(templateDir, 'remediation-report.hbs'),
+        expectContains: [iacMarker],
+      },
+      {
+        scan: 'IaC',
+        flags: 'only -t (explicit IaC template)',
+        fixture: 'iac-test-report.json',
+        remediation: false,
+        template: path.join(templateDir, 'iac', 'test-report.hbs'),
+        expectContains: [iacMarker],
+      },
+      {
+        scan: 'IaC',
+        flags: '-a and -t (explicit IaC template)',
+        fixture: 'iac-test-report.json',
+        remediation: true,
+        template: path.join(templateDir, 'iac', 'test-report.hbs'),
+        expectContains: [iacMarker],
+      },
+      {
+        scan: 'IaC',
+        flags: 'only -t (custom non-IaC template)',
+        fixture: 'iac-test-report.json',
+        remediation: false,
+        template: path.join(templateDir, 'test-cve-report.hbs'),
+        expectNotContains: [iacMarker],
+      },
+      {
+        scan: 'Open Source',
+        flags: 'no -a, no -t (default test-report.hbs)',
+        fixture: 'test-report.json',
+        remediation: false,
+        template: path.join(templateDir, 'test-report.hbs'),
+        expectContains: [ossMarker],
+        expectNotContains: ['Snyk Code Report', iacMarker],
+      },
+      {
+        scan: 'Open Source',
+        flags: 'only -a (default remediation-report.hbs)',
+        fixture: 'test-report.json',
+        remediation: true,
+        template: path.join(templateDir, 'remediation-report.hbs'),
+        expectContains: [
+          ossMarker,
+          '<body class="test-remediation-section-projects">',
+        ],
+        expectNotContains: ['Snyk Code Report', iacMarker],
+      },
+      {
+        scan: 'Open Source',
+        flags: 'only -t (custom template)',
+        fixture: 'test-report.json',
+        remediation: false,
+        template: path.join(templateDir, 'test-cve-report.hbs'),
+        expectContains: [ossMarker],
+        expectNotContains: ['Snyk Code Report', iacMarker],
+      },
+      {
+        scan: 'Open Source',
+        flags: '-a and -t (custom template)',
+        fixture: 'test-report.json',
+        remediation: true,
+        template: path.join(templateDir, 'test-cve-report.hbs'),
+        expectContains: [ossMarker],
+        expectNotContains: ['Snyk Code Report', iacMarker],
+      },
+    ])('$scan | $flags', (testCase, done) => {
+      const input = path.join(fixturesDir, testCase.fixture);
+
+      if (testCase.rejects) {
+        SnykToHtml.runAsync(
+          input,
+          testCase.remediation,
+          testCase.template,
+          WITHOUT_SUMMARY,
+        )
+          .then(() => done(new Error('expected template render to fail')))
+          .catch(() => done());
+        return;
+      }
+
+      SnykToHtml.run(
+        input,
+        testCase.remediation,
+        testCase.template,
+        WITHOUT_SUMMARY,
+        (report) => {
+          try {
+            for (const text of testCase.expectContains ?? []) {
+              expect(report).toContain(text);
+            }
+            for (const text of testCase.expectNotContains ?? []) {
+              expect(report).not.toContain(text);
+            }
+            done();
+          } catch (error: any) {
+            done(error);
+          }
+        },
+      );
+    });
   });
 
   it('generates a report with container app vulnerabilities', (done) => {

--- a/test/snyk-to-html.spec.ts
+++ b/test/snyk-to-html.spec.ts
@@ -500,6 +500,45 @@ describe('test running SnykToHtml.run', () => {
     );
   });
 
+  it('generates a Code report when default template is remediation-report.hbs', (done) => {
+    SnykToHtml.run(
+      path.join(__dirname, 'fixtures/test-code-openrefine.json'),
+      WITH_REMEDIATION,
+      path.join(__dirname, '..', 'template', 'remediation-report.hbs'),
+      WITHOUT_SUMMARY,
+      (report) => {
+        try {
+          expect(report).toContain('Snyk Code Report');
+          expect(report).toContain(
+            '<h2 class="card__title">Path Traversal</h2>',
+          );
+          done();
+        } catch (error: any) {
+          done(error);
+        }
+      },
+    );
+  });
+
+  it('generates an IaC report when default template is remediation-report.hbs', (done) => {
+    SnykToHtml.run(
+      path.join(__dirname, 'fixtures/iac-test-report.json'),
+      WITH_REMEDIATION,
+      path.join(__dirname, '..', 'template', 'remediation-report.hbs'),
+      WITHOUT_SUMMARY,
+      (report) => {
+        try {
+          expect(report).toContain(
+            '<h2 class="card__title">App Service allows FTP deployments</h2>',
+          );
+          done();
+        } catch (error: any) {
+          done(error);
+        }
+      },
+    );
+  });
+
   it('generates a report with container app vulnerabilities', (done) => {
     // report generated with "snyk container test --app-vulns --json" against an image that is using an old debian-based
     // python image and the golang.org/x/crypto/ssh package at a version with a known vulnerability.


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commits are squashed and tidy and are suitable to become release notes

### What this does

Fixes template auto-detection for **Snyk Code** and **IaC** reports when `-a` / `--actionable-remediation` is used without an explicit `-t` template.

**Problem:** With `-a`, `index.ts` defaults to `template/remediation-report.hbs` instead of `template/test-report.hbs`. Code/IaC detection in `runAsync()` only swapped templates when the path exactly matched `test-report.hbs`, so the swap never ran. Partials (e.g. `test-report.code-snip.hbs`) were then resolved from the wrong directory, causing:

- **Code:** `ENOENT: no such file or directory, open .../template/test-report.code-snip.hbs`
- **IaC:** missing partial errors (e.g. `remediation-css`)

Tracked as CLI-1605.

**Fix:** Introduce `isDefaultTemplate()` so both `test-report.hbs` and `remediation-report.hbs` are treated as built-in defaults. Product-specific templates (`template/code/`, `template/iac/`) are selected when the user has not passed a custom `-t` path.

Customer workarounds that remain valid: omit `-a` for Code/IaC, or pass `-t template/code/test-report.hbs` explicitly.

### Notes for the reviewer

**Repro (before fix):**
```bash
npm run build
node dist/index.js -i test/fixtures/test-code-openrefine.json -o /tmp/out.html -a
# ENOENT for template/test-report.code-snip.hbs
```

**Verify (after fix):**
```bash
npm test -- --testPathPatterns=snyk-to-html.spec
node dist/index.js -i test/fixtures/test-code-openrefine.json -o /tmp/code.html -a
node dist/index.js -i test/fixtures/iac-test-report.json -o /tmp/iac.html -a
```

**Review focus:**
- `isDefaultTemplate()` in `src/lib/snyk-to-html.ts` — small helper, used in both IaC and Code branches
- Explicit `-t` paths should still be honoured (no swap when a custom template is provided)
- Two new regression tests mirror the `-a` default template path (`remediation-report.hbs`)

**Out of scope:** `-a` has no meaningful effect on Code/IaC output today; this PR only fixes the crash / wrong-template behaviour, not remediation UX for those scan types.

### Manual test steps

**Setup:**
```bash
git checkout fix/CLI-1605
npm install   # if needed
npm run build
```

**1. Snyk Code + `-a` (reported bug — must succeed after fix):**
```bash
node dist/index.js \
  -i test/fixtures/test-code-openrefine.json \
  -o /tmp/snyk-code-a.html \
  -a
open /tmp/snyk-code-a.html   # macOS; use xdg-open on Linux
```
Expected: HTML file created with **Snyk Code Report** and findings (e.g. “Path Traversal”). No `ENOENT` for `test-report.code-snip.hbs`.

**2. Snyk Code without `-a` (baseline):**
```bash
node dist/index.js \
  -i test/fixtures/test-code-openrefine.json \
  -o /tmp/snyk-code.html
```
Expected: still works as before.

**3. IaC + `-a`:**
```bash
node dist/index.js \
  -i test/fixtures/iac-test-report.json \
  -o /tmp/snyk-iac-a.html \
  -a
open /tmp/snyk-iac-a.html
```
Expected: HTML with IaC issues (e.g. “App Service allows FTP deployments”). No missing-partial errors.

**4. Customer workaround (still valid):**
```bash
node dist/index.js \
  -i test/fixtures/test-code-openrefine.json \
  -o /tmp/snyk-code-t.html \
  -a \
  -t template/code/test-report.hbs
```
Expected: HTML created successfully.

**5. Open Source + `-a` (regression check):**
```bash
node dist/index.js \
  -i test/fixtures/test-report.json \
  -o /tmp/snyk-oss-a.html \
  -a
```
Expected: dependency report with remediation sections (unchanged behaviour).

**6. Real Snyk Code JSON (optional):**
```bash
snyk code test --json-file-output=snyk.sast.json --all-projects
node dist/index.js -i snyk.sast.json -o snyk.sast.html -a
open snyk.sast.html
```

**7. Debug mode (optional):**
```bash
node dist/index.js -d \
  -i test/fixtures/test-code-openrefine.json \
  -o /tmp/out.html \
  -a
```

| Scenario | Expected |
| --- | --- |
| Code JSON + `-a` | HTML created, no ENOENT |
| IaC JSON + `-a` | HTML created, no partial errors |
| Code JSON, no `-a` | Still works |
| OSS JSON + `-a` | Still works with remediation UI |

### Before / after

Reproduces the customer scenario: Code JSON with `-a` and no explicit `-t`.

**Before (`main`):**
```bash
npm run build
node dist/index.js -i test/fixtures/test-code-openrefine.json -o /tmp/out.html -a
# ENOENT: no such file or directory, open '.../template/test-report.code-snip.hbs'
```

**After (`fix/CLI-1605`):**
```bash
npm run build
node dist/index.js -i test/fixtures/test-code-openrefine.json -o /tmp/out.html -a
# Vulnerability snapshot saved at /tmp/out.html

node dist/index.js -i test/fixtures/iac-test-report.json -o /tmp/iac.html -a
# Vulnerability snapshot saved at /tmp/iac.html

npm test -- --testPathPatterns=snyk-to-html.spec
# 34 passed (was 32; +2 regression tests for remediation default template)
```

Sample output: [code.html](https://github.com/user-attachments/files/29807437/code.html), [iac.html](https://github.com/user-attachments/files/29807449/iac.html)

### More information

- [CLI-1605](https://snyksec.atlassian.net/browse/CLI-1605)
- Triage confirmed root cause and noted the same fragile check affected IaC, not only Code

### Screenshots

N/A — CLI/HTML output change only; no UI screenshots.


[CLI-1605]: https://snyksec.atlassian.net/browse/CLI-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ